### PR TITLE
Ensure valid xml on overwriting a longer result file

### DIFF
--- a/src/Xunit.Xml.TestLogger/XunitXmlTestLogger.cs
+++ b/src/Xunit.Xml.TestLogger/XunitXmlTestLogger.cs
@@ -231,7 +231,10 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.Xunit.Xml.TestAdapter
                 Directory.CreateDirectory(loggerFileDirPath);
             }
 
-            doc.Save(File.OpenWrite(outputFilePath));
+            using (var f = File.Create(outputFilePath))
+            {
+                doc.Save(f);
+            }
         }
 
         private XElement CreateAssembliesElement(List<TestResultInfo> results)


### PR DESCRIPTION
[File.OpenWrite][doc] doesn't zero out the content of the file if it already exists.

This may generate invalid xml when the newly generated xml takes less space to be serialized
than the existing xml content of the file.

Additionally, this commit also takes care of releasing the file handle as soon as possible.



 [doc]: https://msdn.microsoft.com/en-us/library/system.io.file.openwrite