### PR TITLE
Use REST interface for AppVeyor

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# http://editorconfig.org
+root=true
+
+[*]
+trim_trailing_whitespace = true
+indent_style = space
+
+[*.cs]
+indent_size = 4

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto

--- a/NuGet.config
+++ b/NuGet.config
@@ -4,6 +4,6 @@
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="faizan2304.Myget" value="https://www.myget.org/F/faizan2304/api/v3/index.json" />
+    <add key="locally_built" value="./nugetPackage" />
   </packageSources>
 </configuration>

--- a/TestPlatform.TestLoggers.sln.DotSettings
+++ b/TestPlatform.TestLoggers.sln.DotSettings
@@ -1,0 +1,4 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeStyle/CSharpUsing/AddImportsToDeepestScope/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CSharpUsing/QualifiedUsingAtNestedScope/@EntryValue">True</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String></wpf:ResourceDictionary>

--- a/nuspec/Appveyor.TestLogger.nuspec
+++ b/nuspec/Appveyor.TestLogger.nuspec
@@ -4,7 +4,7 @@
     <id>Appveyor.TestLogger</id>
     <version>$Version$</version>
     <title>Appveyor.TestLogger</title>
-    <authors>Faizan2304</authors>
+    <authors>Faizan2304,ngbrown</authors>
     <owners>Faizan2304</owners>
 	<projectUrl>https://github.com/Faizan2304/LoggerExtensions</projectUrl>
 	<description>Logger for uploading test result in Appveyor when test is running with "dotnet test". This package is applicable for "dotnet test" which got shipped with visual studio 2017 update 1 and onwards.</description>

--- a/src/Appveyor.TestLogger/AppveyorLoggerQueue.cs
+++ b/src/Appveyor.TestLogger/AppveyorLoggerQueue.cs
@@ -1,0 +1,110 @@
+﻿namespace Microsoft.VisualStudio.TestPlatform.Extensions.Appveyor.TestLogger
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Net.Http;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    internal class AppveyorLoggerQueue
+    {
+        private static readonly HttpClient client = new HttpClient();
+
+        /// <summary>
+        /// it is localhost with a random port, e.g. http://localhost:9023/
+        /// </summary>
+        private readonly string appveyorApiUrl;
+
+        private readonly AsyncProducerConsumerCollection<string> queue = new AsyncProducerConsumerCollection<string>();
+        private readonly Task consumeTask;
+        private readonly CancellationTokenSource consumeTaskCancellationSource = new CancellationTokenSource();
+
+        private int totalEnqueued = 0;
+        private int totalSent = 0;
+
+        public AppveyorLoggerQueue(string appveyorApiUrl)
+        {
+            this.appveyorApiUrl = appveyorApiUrl;
+            this.consumeTask = ConsumeItemsAsync(consumeTaskCancellationSource.Token);
+        }
+
+        public void Enqueue(string json)
+        {
+            queue.Add(json);
+            totalEnqueued++;
+        }
+
+        public void Flush()
+        {
+            // Cancel any idle consumers and let them return
+            queue.Cancel();
+
+            try
+            {
+                // any active consumer will circle back around and batch post the remaining queue.
+                consumeTask.Wait(TimeSpan.FromSeconds(60));
+
+                // Cancel any active HTTP requests if still hasn't finished flushing
+                consumeTaskCancellationSource.Cancel();
+                if (!consumeTask.Wait(TimeSpan.FromSeconds(10)))
+                {
+                    throw new TimeoutException("cancellation didn't happen quickly");
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+            }
+
+#if DEBUG
+            Console.WriteLine("Appveyor.TestLogger: {0} test results reported ({1} enqueued).", totalSent, totalEnqueued);
+#endif
+        }
+
+        private async Task ConsumeItemsAsync(CancellationToken cancellationToken)
+        {
+            while (true)
+            {
+                string[] nextItems = await this.queue.TakeAsync();
+                if (nextItems == null || nextItems.Length == 0) return;      // Queue is cancelling and and empty.
+
+                if (nextItems.Length == 1) await PostItemAsync(nextItems[0], cancellationToken);
+                else if (nextItems.Length > 1) await PostBatchAsync(nextItems, cancellationToken);
+
+                if (cancellationToken.IsCancellationRequested) return;
+            }
+        }
+
+        private async Task PostItemAsync(string json, CancellationToken cancellationToken)
+        {
+            HttpContent content = new StringContent(json, Encoding.UTF8, "application/json");
+            try
+            {
+                var response = await client.PostAsync(appveyorApiUrl + "api/tests", content, cancellationToken);
+                response.EnsureSuccessStatusCode();
+                totalSent += 1;
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+            }
+        }
+
+        private async Task PostBatchAsync(ICollection<string> jsonEntities, CancellationToken cancellationToken)
+        {
+            var jsonArray = "[" + string.Join(",", jsonEntities) + "]";
+            HttpContent content = new StringContent(jsonArray, Encoding.UTF8, "application/json");
+            try
+            {
+                var response = await client.PostAsync(appveyorApiUrl + "api/tests/batch", content, cancellationToken);
+                response.EnsureSuccessStatusCode();
+                totalSent += jsonEntities.Count;
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+            }
+        }
+    }
+}

--- a/src/Appveyor.TestLogger/AsyncProducerConsumerCollection.cs
+++ b/src/Appveyor.TestLogger/AsyncProducerConsumerCollection.cs
@@ -1,0 +1,70 @@
+﻿namespace Microsoft.VisualStudio.TestPlatform.Extensions.Appveyor.TestLogger
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    /// <remarks>
+    /// Adopted from https://docs.microsoft.com/en-us/dotnet/standard/asynchronous-programming-patterns/consuming-the-task-based-asynchronous-pattern
+    /// </remarks>
+    internal class AsyncProducerConsumerCollection<T>
+    {
+        private readonly Queue<T> collection = new Queue<T>();
+        private readonly Queue<TaskCompletionSource<T[]>> waiting = new Queue<TaskCompletionSource<T[]>>();
+        private bool canceled = false;
+
+        public void Cancel()
+        {
+            TaskCompletionSource<T[]>[] allWaiting;
+            lock (collection)
+            {
+                canceled = true;
+                allWaiting = waiting.ToArray();
+                waiting.Clear();
+            }
+
+            foreach (var tcs in allWaiting)
+            {
+                tcs.TrySetResult(new T[] { });
+            }
+        }
+
+        public void Add(T item)
+        {
+            TaskCompletionSource<T[]> tcs = null;
+            lock (collection)
+            {
+                if (waiting.Count > 0) tcs = waiting.Dequeue();
+                else collection.Enqueue(item);
+            }
+
+            tcs?.TrySetResult(new [] {item});
+        }
+
+        /// <summary>
+        /// Queue producer for consumers to <c>await</c> on.
+        /// </summary>
+        /// <returns>Array of all available items.  Empty array if queue is being canceled.</returns>
+        public Task<T[]> TakeAsync()
+        {
+            lock (collection)
+            {
+                if (collection.Count > 0)
+                {
+                    var result = Task.FromResult(collection.ToArray());
+                    collection.Clear();
+                    return result;
+                }
+                else if (canceled == false)
+                {
+                    var tcs = new TaskCompletionSource<T[]>();
+                    waiting.Enqueue(tcs);
+                    return tcs.Task;
+                }
+                else // canceled == true
+                {
+                    return Task.FromResult(new T[] { });
+                }
+            }
+        }
+    }
+}

--- a/src/Appveyor.TestLogger/JsonEscape.cs
+++ b/src/Appveyor.TestLogger/JsonEscape.cs
@@ -1,0 +1,74 @@
+namespace Microsoft.VisualStudio.TestPlatform.Extensions.Appveyor.TestLogger
+{
+    using System.Text;
+
+    /// <remarks>
+    /// From https://github.com/facebook-csharp-sdk/simple-json/blob/master/src/SimpleJson/SimpleJson.cs
+    /// </remarks>
+    internal class JsonEscape
+    {
+        private static readonly char[] EscapeTable;
+        private static readonly char[] EscapeCharacters = { '"', '\\', '\b', '\f', '\n', '\r', '\t' };
+
+        static JsonEscape()
+        {
+            EscapeTable = new char[93];
+            EscapeTable['"'] = '"';
+            EscapeTable['\\'] = '\\';
+            EscapeTable['\b'] = 'b';
+            EscapeTable['\f'] = 'f';
+            EscapeTable['\n'] = 'n';
+            EscapeTable['\r'] = 'r';
+            EscapeTable['\t'] = 't';
+        }
+
+        public static bool SerializeString(string aString, StringBuilder builder)
+        {
+            // Happy path if there's nothing to be escaped. IndexOfAny is highly optimized (and unmanaged)
+            if (aString.IndexOfAny(EscapeCharacters) == -1)
+            {
+                builder.Append('"');
+                builder.Append(aString);
+                builder.Append('"');
+
+                return true;
+            }
+
+            builder.Append('"');
+            int safeCharacterCount = 0;
+            char[] charArray = aString.ToCharArray();
+
+            for (int i = 0; i < charArray.Length; i++)
+            {
+                char c = charArray[i];
+
+                // Non ascii characters are fine, buffer them up and send them to the builder
+                // in larger chunks if possible. The escape table is a 1:1 translation table
+                // with \0 [default(char)] denoting a safe character.
+                if (c >= EscapeTable.Length || EscapeTable[c] == default(char))
+                {
+                    safeCharacterCount++;
+                }
+                else
+                {
+                    if (safeCharacterCount > 0)
+                    {
+                        builder.Append(charArray, i - safeCharacterCount, safeCharacterCount);
+                        safeCharacterCount = 0;
+                    }
+
+                    builder.Append('\\');
+                    builder.Append((char) EscapeTable[c]);
+                }
+            }
+
+            if (safeCharacterCount > 0)
+            {
+                builder.Append(charArray, charArray.Length - safeCharacterCount, safeCharacterCount);
+            }
+
+            builder.Append('"');
+            return true;
+        }
+    }
+}

--- a/test/Appveyor.TestLogger.NetCore.Tests/Appveyor.TestLogger.NetCore.Tests.csproj
+++ b/test/Appveyor.TestLogger.NetCore.Tests/Appveyor.TestLogger.NetCore.Tests.csproj
@@ -11,4 +11,8 @@
     <PackageReference Include="Appveyor.TestLogger" Version="1.1.0-post-rtm" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
 </Project>

--- a/test/Appveyor.TestLogger.NetCore.Tests/Appveyor.TestLogger.NetCore.Tests.csproj
+++ b/test/Appveyor.TestLogger.NetCore.Tests/Appveyor.TestLogger.NetCore.Tests.csproj
@@ -2,13 +2,14 @@
 
   <PropertyGroup>    
     <TargetFrameworks>netcoreapp1.0</TargetFrameworks>
+    <Version Condition=" '$(Version)' == '' ">1.0.0-dev</Version>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.11" />
     <PackageReference Include="MSTest.TestFramework" Version="1.1.11" />
-    <PackageReference Include="Appveyor.TestLogger" Version="1.1.0-post-rtm" />
+    <PackageReference Include="Appveyor.TestLogger" Version="[$(Version)]" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Appveyor.TestLogger.NetFull.Tests/Appveyor.TestLogger.NetFull.Tests.csproj
+++ b/test/Appveyor.TestLogger.NetFull.Tests/Appveyor.TestLogger.NetFull.Tests.csproj
@@ -2,13 +2,14 @@
 
   <PropertyGroup>    
     <TargetFramework>net46</TargetFramework>
+    <Version Condition=" '$(Version)' == '' ">1.0.0-dev</Version>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.11" />
     <PackageReference Include="MSTest.TestFramework" Version="1.1.11" />
-    <PackageReference Include="Appveyor.TestLogger" Version="1.1.0-post-rtm" />
+    <PackageReference Include="Appveyor.TestLogger" Version="[$(Version)]" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Xunit.Xml.TestLogger.NetCore.Tests/Xunit.Xml.TestLogger.NetCore.Tests.csproj
+++ b/test/Xunit.Xml.TestLogger.NetCore.Tests/Xunit.Xml.TestLogger.NetCore.Tests.csproj
@@ -11,4 +11,8 @@
     <PackageReference Include="XunitXml.TestLogger" Version="1.1.0-post-rtm" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
 </Project>

--- a/test/Xunit.Xml.TestLogger.NetCore.Tests/Xunit.Xml.TestLogger.NetCore.Tests.csproj
+++ b/test/Xunit.Xml.TestLogger.NetCore.Tests/Xunit.Xml.TestLogger.NetCore.Tests.csproj
@@ -2,13 +2,14 @@
 
   <PropertyGroup>    
     <TargetFramework>netcoreapp1.0</TargetFramework>
+    <Version Condition=" '$(Version)' == '' ">1.0.0-dev</Version>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="XunitXml.TestLogger" Version="1.1.0-post-rtm" />
+    <PackageReference Include="XunitXml.TestLogger" Version="[$(Version)]" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Xunit.Xml.TestLogger.NetFull.Tests/Xunit.Xml.TestLogger.NetFull.Tests.csproj
+++ b/test/Xunit.Xml.TestLogger.NetFull.Tests/Xunit.Xml.TestLogger.NetFull.Tests.csproj
@@ -2,13 +2,14 @@
 
   <PropertyGroup>    
     <TargetFramework>net46</TargetFramework>
+    <Version Condition=" '$(Version)' == '' ">1.0.0-dev</Version>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="XunitXml.TestLogger" Version="1.1.0-post-rtm" />
+    <PackageReference Include="XunitXml.TestLogger" Version="[$(Version)]" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The use of a blocking command-line tool per test is quite slow.  It caused my tests to be canceled at the 60 minute limit with only 2,559 completed.

The changes use a Async queue and HTTP batch POST to minimize the time impact on builds with a large number of tests.  With these changes, all 5,781 test complete in 19 minutes.