### PR TITLE
Add a logger for NUnit XML format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,6 @@ ehthumbs.db
 packages
 nugetPackage
 [tT]ools
+
+# Rider
+.idea

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Reporting extensions for [Visual Studio Test Platform](https://gtihub.com/micros
 | Logger | Nuget Package |
 | ------ | ------------- |
 | AppVeyor | [![NuGet](https://img.shields.io/nuget/v/Appveyor.TestLogger.svg)](https://www.nuget.org/packages/Appveyor.TestLogger/) |
+| NUnit | [![NuGet](https://img.shields.io/nuget/v/NUnitXml.TestLogger.svg)](https://www.nuget.org/packages/NUnitXml.TestLogger/) |
 | Xunit | [![NuGet](https://img.shields.io/nuget/v/XunitXml.TestLogger.svg)](https://www.nuget.org/packages/XunitXml.TestLogger/) |
 
 ## Usage
@@ -19,6 +20,24 @@ The appveyor logger can report test results automatically to the CI build. See a
 > dotnet test --test-adapter-path:. --logger:Appveyor
 ```
 3. Test results are automatically reported to the AppVeyor CI results
+
+
+### NUnit Logger
+NUnit logger can generate xml reports in the NUnit v3 format (https://github.com/nunit/docs/wiki/Test-Result-XML-Format).
+
+1. Add a reference to the [NUnit Logger](https://www.nuget.org/packages/NUnitXml.TestLogger) nuget package in test project
+2. Use the following command line in tests
+```
+> dotnet test --test-adapter-path:. --logger:nunit
+```
+3. Test results are generated in the `TestResults` directory relative to the `test.csproj`
+
+A path for the report file can be specified as follows:
+```
+> dotnet test --test-adapter-path:. --logger:nunit;LogFilePath=loggerFile.xml
+```
+
+`loggerFile.xml` will be generated in the same directory as `test.csproj`.
  
 ### Xunit Logger
 Xunit logger can generate xml reports in the xunit v2 format (https://xunit.github.io/docs/format-xml-v2.html).

--- a/TestPlatform.TestLoggers.sln
+++ b/TestPlatform.TestLoggers.sln
@@ -23,6 +23,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Restore", "src\ExternalPack
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Xunit.Xml.TestLogger.NetFull.Tests", "test\Xunit.Xml.TestLogger.NetFull.Tests\Xunit.Xml.TestLogger.NetFull.Tests.csproj", "{269D6102-6163-4AD8-A89A-9965B9F24A52}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NUnit.Xml.TestLogger.NetCore.Tests", "test\NUnit.Xml.TestLogger.NetCore.Tests\NUnit.Xml.TestLogger.NetCore.Tests.csproj", "{AEA0096F-64C1-4A10-9AD5-B4BB5A990D5A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NUnit.Xml.TestLogger.NetFull.Tests", "test\NUnit.Xml.TestLogger.NetFull.Tests\NUnit.Xml.TestLogger.NetFull.Tests.csproj", "{01F109DC-1379-4AB2-86E8-83CA1A06B39F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NUnit.Xml.TestLogger", "src\NUnit.Xml.TestLogger\NUnit.Xml.TestLogger.csproj", "{E8C9763A-ED00-4093-A311-E8B13DCDD75F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -57,6 +63,18 @@ Global
 		{269D6102-6163-4AD8-A89A-9965B9F24A52}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{269D6102-6163-4AD8-A89A-9965B9F24A52}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{269D6102-6163-4AD8-A89A-9965B9F24A52}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AEA0096F-64C1-4A10-9AD5-B4BB5A990D5A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AEA0096F-64C1-4A10-9AD5-B4BB5A990D5A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AEA0096F-64C1-4A10-9AD5-B4BB5A990D5A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AEA0096F-64C1-4A10-9AD5-B4BB5A990D5A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{01F109DC-1379-4AB2-86E8-83CA1A06B39F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{01F109DC-1379-4AB2-86E8-83CA1A06B39F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{01F109DC-1379-4AB2-86E8-83CA1A06B39F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{01F109DC-1379-4AB2-86E8-83CA1A06B39F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E8C9763A-ED00-4093-A311-E8B13DCDD75F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E8C9763A-ED00-4093-A311-E8B13DCDD75F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E8C9763A-ED00-4093-A311-E8B13DCDD75F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E8C9763A-ED00-4093-A311-E8B13DCDD75F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -70,5 +88,8 @@ Global
 		{FAA6D063-39D2-4F32-997C-6DA27BC9B489} = {3FB5E8BF-B24A-4246-97B8-B98E028457BF}
 		{5E600330-4DDD-4D5A-B668-E8AD545025DD} = {FAA6D063-39D2-4F32-997C-6DA27BC9B489}
 		{269D6102-6163-4AD8-A89A-9965B9F24A52} = {2A90596D-42AC-49DB-B5BF-72E1AFD7A066}
+		{AEA0096F-64C1-4A10-9AD5-B4BB5A990D5A} = {2A90596D-42AC-49DB-B5BF-72E1AFD7A066}
+		{01F109DC-1379-4AB2-86E8-83CA1A06B39F} = {2A90596D-42AC-49DB-B5BF-72E1AFD7A066}
+		{E8C9763A-ED00-4093-A311-E8B13DCDD75F} = {3FB5E8BF-B24A-4246-97B8-B98E028457BF}
 	EndGlobalSection
 EndGlobal

--- a/src/NUnit.Xml.TestLogger/NUnit.Xml.TestLogger.csproj
+++ b/src/NUnit.Xml.TestLogger/NUnit.Xml.TestLogger.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard1.5</TargetFramework>
+    <AssemblyName>Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger</AssemblyName>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <RootNamespace>Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="15.0.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.3.0" />
+  </ItemGroup>
+</Project>

--- a/src/NUnit.Xml.TestLogger/NUnitXmlTestLogger.cs
+++ b/src/NUnit.Xml.TestLogger/NUnitXmlTestLogger.cs
@@ -1,0 +1,501 @@
+﻿namespace Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.IO;
+    using System.Linq;
+    using System.Xml.Linq;
+    using System.Text;
+    using System.Text.RegularExpressions;
+    using ObjectModel;
+    using ObjectModel.Client;
+    using ObjectModel.Logging;
+
+    [FriendlyName(FriendlyName)]
+    [ExtensionUri(ExtensionUri)]
+    public class NUnitXmlTestLogger : ITestLoggerWithParameters
+    {
+        /// <summary>
+        /// Uri used to uniquely identify the logger.
+        /// </summary>
+        public const string ExtensionUri = "logger://Microsoft/TestPlatform/NUnitXmlLogger/v1";
+
+        /// <summary>
+        /// Alternate user friendly string to uniquely identify the console logger.
+        /// </summary>
+        public const string FriendlyName = "nunit";
+
+        public const string LogFilePathKey = "LogFilePath";
+        public const string EnvironmentKey = "Environment";
+        public const string NUnitVersionKey = "NUnitVersion";
+
+        private const string ResultStatusPassed = "Passed";
+        private const string ResultStatusFailed = "Failed";
+
+        private string outputFilePath;
+        private string environmentOpt;
+        private string nunitVersionOpt;
+
+        private readonly object resultsGuard = new object();
+        private List<TestResultInfo> results;
+        private DateTime localStartTime;
+
+        private class TestResultInfo
+        {
+            private readonly TestResult result;
+            public TestCase TestCase => result.TestCase;
+            public TestOutcome Outcome => result.Outcome;
+            public string AssemblyPath => result.TestCase.Source;
+            public readonly string Type;
+            public readonly string Method;
+            public string Name => result.TestCase.DisplayName;
+            public TimeSpan Time => result.Duration;
+            public string ErrorMessage => result.ErrorMessage;
+            public string ErrorStackTrace => result.ErrorStackTrace;
+            public IReadOnlyCollection<TestResultMessage> Messages => result.Messages;
+            public TraitCollection Traits => result.Traits;
+
+            public TestResultInfo(
+                TestResult result,
+                string type,
+                string method)
+            {
+                this.result = result;
+                Type = type;
+                Method = method;
+            }
+
+            public override int GetHashCode()
+            {
+                return result.GetHashCode();
+            }
+
+            public override bool Equals(object obj)
+            {
+                if (obj is TestResultInfo)
+                {
+                    TestResultInfo objectToCompare = (TestResultInfo) obj;
+                    if (string.Compare(ErrorMessage, objectToCompare.ErrorMessage) == 0
+                        && string.Compare(ErrorStackTrace, objectToCompare.ErrorStackTrace) == 0)
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+        }
+
+        public void Initialize(TestLoggerEvents events, string testResultsDirPath)
+        {
+            if (events == null)
+            {
+                throw new ArgumentNullException(nameof(events));
+            }
+
+            if (testResultsDirPath == null)
+            {
+                throw new ArgumentNullException(nameof(testResultsDirPath));
+            }
+
+            var outputPath = Path.Combine(testResultsDirPath, "TestResults.xml");
+            InitializeImpl(events, outputPath);
+        }
+
+        public void Initialize(TestLoggerEvents events, Dictionary<string, string> parameters)
+        {
+            if (events == null)
+            {
+                throw new ArgumentNullException(nameof(events));
+            }
+
+            if (parameters == null)
+            {
+                throw new ArgumentNullException(nameof(parameters));
+            }
+
+            if (parameters.TryGetValue(LogFilePathKey, out string outputPath))
+            {
+                InitializeImpl(events, outputPath);
+            }
+            else if (parameters.TryGetValue(DefaultLoggerParameterNames.TestRunDirectory, out string outputDir))
+            {
+                Initialize(events, outputDir);
+            }
+            else
+            {
+                throw new ArgumentException($"Expected {LogFilePathKey} or {DefaultLoggerParameterNames.TestRunDirectory} parameter", nameof(parameters));
+            }
+
+            parameters.TryGetValue(EnvironmentKey, out environmentOpt);
+            parameters.TryGetValue(NUnitVersionKey, out nunitVersionOpt);
+        }
+
+        private void InitializeImpl(TestLoggerEvents events, string outputPath)
+        {
+            events.TestRunMessage += TestMessageHandler;
+            events.TestResult += TestResultHandler;
+            events.TestRunComplete += TestRunCompleteHandler;
+
+            outputFilePath = Path.GetFullPath(outputPath);
+
+            lock (resultsGuard)
+            {
+                results = new List<TestResultInfo>();
+            }
+
+            localStartTime = DateTime.Now;
+        }
+
+        /// <summary>
+        /// Called when a test message is received.
+        /// </summary>
+        internal void TestMessageHandler(object sender, TestRunMessageEventArgs e)
+        {
+        }
+
+        /// <summary>
+        /// Called when a test result is received.
+        /// </summary>
+        internal void TestResultHandler(object sender, TestResultEventArgs e)
+        {
+            TestResult result = e.Result;
+
+            if (TryParseName(result.TestCase.FullyQualifiedName, out var typeName, out var methodName, out _))
+            {
+                lock (resultsGuard)
+                {
+                    results.Add(new TestResultInfo(
+                        result,
+                        typeName,
+                        methodName));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Called when a test run is completed.
+        /// </summary>
+        internal void TestRunCompleteHandler(object sender, TestRunCompleteEventArgs e)
+        {
+            List<TestResultInfo> resultList;
+            lock (resultsGuard)
+            {
+                resultList = results;
+                results = new List<TestResultInfo>();
+            }
+
+            var doc = new XDocument(CreateAssembliesElement(resultList));
+
+            // Create directory if not exist
+            var loggerFileDirPath = Path.GetDirectoryName(outputFilePath);
+            if (!Directory.Exists(loggerFileDirPath))
+            {
+                Directory.CreateDirectory(loggerFileDirPath);
+            }
+
+            using (var f = File.Create(outputFilePath))
+            {
+                doc.Save(f);
+            }
+
+            var resultsFileMessage = string.Format(CultureInfo.CurrentCulture, "Results File: {0}", outputFilePath);
+            Console.WriteLine(resultsFileMessage);
+        }
+
+        private XElement CreateAssembliesElement(List<TestResultInfo> results)
+        {
+            var testSuites = from result in results
+                group result by result.AssemblyPath
+                into resultsByAssembly
+                orderby resultsByAssembly.Key
+                select CreateTestSuiteElement(resultsByAssembly);
+
+            var element = new XElement("test-run", testSuites);
+
+            element.SetAttributeValue("id", 2);
+
+            var resultString = DetermineResultFromDescendants(element, "test-suite");
+            element.SetAttributeValue("result", resultString);
+            element.SetAttributeValue("time", results.Sum(x => x.Time.TotalSeconds));
+
+            var total = testSuites.Sum(x => (int) x.Attribute("total"));
+
+            // TODO test case count is actually count before filtering
+            element.SetAttributeValue("testcasecount", total);
+            element.SetAttributeValue("total", total);
+            element.SetAttributeValue("passed", testSuites.Sum(x => (int) x.Attribute("passed")));
+            element.SetAttributeValue("failed", testSuites.Sum(x => (int) x.Attribute("failed")));
+            element.SetAttributeValue("skipped", testSuites.Sum(x => (int) x.Attribute("skipped")));
+
+            element.SetAttributeValue("run-date", localStartTime.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
+            element.SetAttributeValue("run-time", localStartTime.ToString("HH:mm:ss", CultureInfo.InvariantCulture));
+
+            return element;
+        }
+
+        private static string DetermineResultFromDescendants(XElement element, string descendantElementName)
+        {
+            string resultString = ResultStatusPassed;
+            foreach (var x in element.Descendants(descendantElementName))
+            {
+                if (ResultStatusFailed.Equals((string) x.Attribute("result"), StringComparison.OrdinalIgnoreCase))
+                {
+                    resultString = ResultStatusFailed;
+                    break;
+                }
+            }
+            return resultString;
+        }
+
+        private XElement CreateTestSuiteElement(IGrouping<string, TestResultInfo> resultsByAssembly)
+        {
+            var assemblyPath = resultsByAssembly.Key;
+
+            var collections = from resultsInAssembly in resultsByAssembly
+                group resultsInAssembly by resultsInAssembly.Type
+                into resultsByType
+                orderby resultsByType.Key
+                select CreateTestSuite(resultsByType);
+
+            int total = 0;
+            int passed = 0;
+            int failed = 0;
+            int skipped = 0;
+            int errors = 0;
+            var time = TimeSpan.Zero;
+
+            var element = new XElement("test-suite");
+            element.SetAttributeValue("type", "Assembly");
+
+            XElement errorsElement = new XElement("errors");
+            element.Add(errorsElement);
+
+            foreach (var collection in collections)
+            {
+                total += collection.total;
+                passed += collection.passed;
+                failed += collection.failed;
+                skipped += collection.skipped;
+                errors += collection.error;
+                time += collection.time;
+
+                element.Add(collection.element);
+            }
+
+            element.SetAttributeValue("name", Path.GetFileName(assemblyPath));
+            element.SetAttributeValue("fullname", assemblyPath);
+
+            element.SetAttributeValue("total", total);
+            element.SetAttributeValue("passed", passed);
+            element.SetAttributeValue("failed", failed);
+            element.SetAttributeValue("skipped", skipped);
+            element.SetAttributeValue("time", time.TotalSeconds.ToString("N3", CultureInfo.InvariantCulture));
+            element.SetAttributeValue("errors", errors);
+
+            return element;
+        }
+
+        private static XElement CreateErrorElement(TestResultInfo result)
+        {
+            string errorMessage = result.ErrorMessage;
+
+            int indexOfErrorType = errorMessage.IndexOf('(');
+            errorMessage = errorMessage.Substring(indexOfErrorType + 1);
+
+            int indexOfName = errorMessage.IndexOf(')');
+            string name = errorMessage.Substring(0, indexOfName);
+            errorMessage = errorMessage.Substring(indexOfName + 4);
+
+            int indexOfExceptionType = errorMessage.IndexOf(':');
+            string exceptionType = errorMessage.Substring(0, indexOfExceptionType - 1);
+
+            XElement errorElement = new XElement("error");
+            errorElement.SetAttributeValue("name", name);
+
+            errorElement.Add(CreateFailureElement(exceptionType, errorMessage, result.ErrorStackTrace));
+
+            return errorElement;
+        }
+
+        private static XElement CreateFailureElement(string exceptionType, string message, string stackTrace)
+        {
+            XElement failureElement = new XElement("failure", new XAttribute("exception-type", exceptionType));
+            failureElement.Add(new XElement("message", RemoveInvalidXmlChar(message)));
+            failureElement.Add(new XElement("stack-trace", RemoveInvalidXmlChar(stackTrace)));
+
+            return failureElement;
+        }
+
+        private static (XElement element, int total, int passed, int failed, int skipped, int error, TimeSpan time) CreateTestSuite(IGrouping<string, TestResultInfo> resultsByType
+        )
+        {
+            var element = new XElement("test-suite");
+
+            int total = 0;
+            int passed = 0;
+            int failed = 0;
+            int skipped = 0;
+            int error = 0;
+            var time = TimeSpan.Zero;
+
+            foreach (var result in resultsByType)
+            {
+                switch (result.Outcome)
+                {
+                    case TestOutcome.Failed:
+                        failed++;
+                        break;
+
+                    case TestOutcome.Passed:
+                        passed++;
+                        break;
+
+                    case TestOutcome.Skipped:
+                    case TestOutcome.None:
+                        skipped++;
+                        break;
+                }
+
+                total++;
+                time += result.Time;
+
+                element.Add(CreateTestElement(result));
+            }
+
+            var name = resultsByType.Key;
+            var idx = name.LastIndexOf('.');
+            if (idx != -1)
+            {
+                name = name.Substring(idx + 1);
+            }
+            element.SetAttributeValue("type", "TestFixture");
+            element.SetAttributeValue("name", name);
+            element.SetAttributeValue("fullname", resultsByType.Key);
+
+            var resultString = DetermineResultFromDescendants(element, "test-case");
+            element.SetAttributeValue("result", resultString);
+
+            element.SetAttributeValue("total", total);
+            element.SetAttributeValue("passed", passed);
+            element.SetAttributeValue("failed", failed);
+            element.SetAttributeValue("skipped", skipped);
+            element.SetAttributeValue("time", time.TotalSeconds.ToString("N3", CultureInfo.InvariantCulture));
+
+            return (element, total, passed, failed, skipped, error, time);
+        }
+
+        private static XElement CreateTestElement(TestResultInfo result)
+        {
+            var element = new XElement("test-case",
+                new XAttribute("name", result.Name),
+                new XAttribute("fullname", result.Type + "." + result.Method),
+                new XAttribute("result", OutcomeToString(result.Outcome)),
+                new XAttribute("time", result.Time.TotalSeconds.ToString("N7", CultureInfo.InvariantCulture)),
+                new XAttribute("asserts", 0));
+
+            StringBuilder stdOut = new StringBuilder();
+            foreach (var m in result.Messages)
+            {
+                if (TestResultMessage.StandardOutCategory.Equals(m.Category, StringComparison.OrdinalIgnoreCase))
+                {
+                    stdOut.AppendLine(m.Text);
+                }
+            }
+
+            if (result.Outcome == TestOutcome.Failed)
+            {
+                element.Add(new XElement("failure",
+                    new XElement("message", RemoveInvalidXmlChar(result.ErrorMessage)),
+                    new XElement("stack-trace", RemoveInvalidXmlChar(result.ErrorStackTrace))));
+            }
+
+            return element;
+        }
+
+        private static bool TryParseName(string testCaseName, out string metadataTypeName, out string metadataMethodName, out string metadataMethodArguments)
+        {
+            // This is fragile. The FQN is constructed by a test adapter. 
+            // There is no enforcement that the FQN starts with metadata type name.
+
+            string typeAndMethodName;
+            var methodArgumentsStart = testCaseName.IndexOf('(');
+
+            if (methodArgumentsStart == -1)
+            {
+                typeAndMethodName = testCaseName.Trim();
+                metadataMethodArguments = string.Empty;
+            }
+            else
+            {
+                typeAndMethodName = testCaseName.Substring(0, methodArgumentsStart).Trim();
+                metadataMethodArguments = testCaseName.Substring(methodArgumentsStart).Trim();
+
+                if (metadataMethodArguments[metadataMethodArguments.Length - 1] != ')')
+                {
+                    metadataTypeName = null;
+                    metadataMethodName = null;
+                    metadataMethodArguments = null;
+                    return false;
+                }
+            }
+
+            var typeNameLength = typeAndMethodName.LastIndexOf('.');
+            var methodNameStart = typeNameLength + 1;
+
+            if (typeNameLength <= 0 || methodNameStart == typeAndMethodName.Length) // No typeName is available
+            {
+                metadataTypeName = null;
+                metadataMethodName = null;
+                metadataMethodArguments = null;
+                return false;
+            }
+
+            metadataTypeName = typeAndMethodName.Substring(0, typeNameLength).Trim();
+            metadataMethodName = typeAndMethodName.Substring(methodNameStart).Trim();
+            return true;
+        }
+
+        private static string OutcomeToString(TestOutcome outcome)
+        {
+            switch (outcome)
+            {
+                case TestOutcome.Failed:
+                    return ResultStatusFailed;
+
+                case TestOutcome.Passed:
+                    return "Passed";
+
+                case TestOutcome.Skipped:
+                    return "Skipped";
+
+                default:
+                    return "Inconclusive";
+            }
+        }
+
+        private static string RemoveInvalidXmlChar(string str)
+        {
+            if (str != null)
+            {
+                // From xml spec (http://www.w3.org/TR/xml/#charsets) valid chars: 
+                // #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]  
+
+                // we are handling only #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD]
+                // because C# support unicode character in range \u0000 to \uFFFF
+                MatchEvaluator evaluator = new MatchEvaluator(ReplaceInvalidCharacterWithUniCodeEscapeSequence);
+                string invalidChar = @"[^\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD]";
+                return Regex.Replace(str, invalidChar, evaluator);
+            }
+
+            return str;
+        }
+
+        private static string ReplaceInvalidCharacterWithUniCodeEscapeSequence(Match match)
+        {
+            char x = match.Value[0];
+            return string.Format(@"\u{0:x4}", (ushort) x);
+        }
+    }
+}

--- a/test/NUnit.Xml.TestLogger.NetCore.Tests/NUnit.Xml.TestLogger.NetCore.Tests.csproj
+++ b/test/NUnit.Xml.TestLogger.NetCore.Tests/NUnit.Xml.TestLogger.NetCore.Tests.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp1.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="NUnit" Version="3.7.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\NUnit.Xml.TestLogger\NUnit.Xml.TestLogger.csproj" />
+  </ItemGroup>
+</Project>

--- a/test/NUnit.Xml.TestLogger.NetCore.Tests/UnitTest1.cs
+++ b/test/NUnit.Xml.TestLogger.NetCore.Tests/UnitTest1.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace NUnit.Xml.TestLogger.NetFull.Tests
+{
+    [TestFixture]
+    public class UnitTest1
+    {
+        [Test]
+        [Description("Passing test description")]
+        public async Task PassTest11()
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(400));
+        }
+
+        [Test]
+        public void FailTest11()
+        {
+            Assert.False(true);
+        }
+
+        [Test]
+        public void Inconclusive()
+        {
+            Assert.Inconclusive("test inconclusive");
+        }
+
+        [Test]
+        [Ignore("ignore reason")]
+        public void Ignored()
+        {
+        }
+    }
+
+    public class UnitTest2
+    {
+        [Test]
+        [Category("passing category")]
+        public void PassTest21()
+        {
+            Assert.That(2, Is.EqualTo(2));
+        }
+
+        [Test]
+        [Category("failing category")]
+        public void FailTest22()
+        {
+            Assert.False(true);
+        }
+
+        [Test]
+        public void Inconclusive()
+        {
+            Assert.Inconclusive();
+        }
+
+        [Test]
+        [Ignore("ignore reason")]
+        public void IgnoredTest()
+        {
+        }
+        
+        [Test]
+        public void WarningTest()
+        {
+            Assert.Warn("Warning");
+        }
+
+        [Test]
+        [Explicit]
+        public void ExplicitTest()
+        {
+        }
+    }
+
+    [TestFixture]
+    public class SuccessFixture
+    {
+        [Test]
+        public void SuccessTest()
+        {
+        }
+    }
+    
+    [TestFixture]
+    public class SuccessAndInconclusiveFixture
+    {
+        [Test]
+        public void SuccessTest()
+        {
+        }
+
+        [Test]
+        public void InconclusiveTest()
+        {
+            Assert.Inconclusive();
+        }
+    }
+    
+    [TestFixture]
+    public class FailingOneTimeSetUp
+    {
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            throw new InvalidOperationException();
+        }
+
+        [Test]
+        public void Test()
+        {
+        }
+    }
+
+    [TestFixture]
+    public class FailingTestSetup
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            throw new InvalidOperationException();
+        }
+        
+        [Test]
+        public void Test()
+        {
+        }
+    }
+
+    [TestFixture]
+    public class FailingTearDown
+    {
+        [TearDown]
+        public void TearDown()
+        {
+            throw new InvalidOperationException();
+        }
+
+        [Test]
+        public void Test()
+        {
+        }
+    }
+
+    [TestFixture]
+    public class FailingOneTimeTearDown
+    {
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            throw new InvalidOperationException();
+        }
+
+        [Test]
+        public void Test()
+        {
+        }
+    }
+    
+    [TestFixture]
+    [TestFixtureSource("FixtureArgs")]
+    public class ParametrizedFixture
+    {
+        public ParametrizedFixture(string word, int num)
+        {
+        }
+
+        [Test]
+        public void Test()
+        {
+        }
+
+        static object[] FixtureArgs =
+        {
+            new object[] {"Question", 1},
+            new object[] {"Answer", 42}
+        };
+    }
+    
+    [TestFixture]
+    public class ParametrizedTestCases
+    {
+        [Test]
+        public void TestData([Values(1, 2)] int x, [Values("A", "B")] string s)
+        {
+            Assert.That(x, Is.Not.EqualTo(2), "failing for second case");
+            Assert.That(s, Is.Not.Null);
+        }
+    }
+}

--- a/test/NUnit.Xml.TestLogger.NetFull.Tests/NUnit.Xml.TestLogger.NetFull.Tests.csproj
+++ b/test/NUnit.Xml.TestLogger.NetFull.Tests/NUnit.Xml.TestLogger.NetFull.Tests.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net461</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="NUnit" Version="3.7.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\NUnit.Xml.TestLogger\NUnit.Xml.TestLogger.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\NUnit.Xml.TestLogger.NetCore.Tests\UnitTest1.cs">
+      <Link>UnitTest1.cs</Link>
+    </Compile>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Here's the initial version of NUnit logger that should produce quite compliant NUnit v3 output. I tested this with some CI server parser plugins and seemed to work. I would believe this is at least a good start to build on.

I based the work on xUnit version and derived needed changes.