### PR TITLE
Fix path of nunit assemblies in package.

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -31,9 +31,9 @@ $env:LE_PACKAGES_DIR = Join-Path $env:LE_ROOT_DIR "packages"
 #
 # Dotnet configuration
 #
-# Disable first run since we want to control all package sources 
+# Disable first run since we want to control all package sources
 Write-Verbose "Setup dotnet configuration."
-$env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = 1 
+$env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = 1
 $env:NUGET_PACKAGES = $env:LE_PACKAGES_DIR
 $env:DOTNET_CLI_VERSION = "latest"
 $env:NUGET_EXE_Version = "3.4.3"
@@ -127,7 +127,7 @@ function Invoke-Build
     $dotnetExe = Get-DotNetPath
 
     $LoggerProjects = (Join-Path $env:LE_ROOT_DIR "src\Appveyor.TestLogger\Appveyor.TestLogger.csproj"),(Join-Path $env:LE_ROOT_DIR "src\Xunit.Xml.TestLogger\Xunit.Xml.TestLogger.csproj"),(Join-Path $env:LE_ROOT_DIR "src\NUnit.Xml.TestLogger\NUnit.Xml.TestLogger.csproj"),(Join-Path $env:LE_ROOT_DIR "src\Appveyor.TestLogger.TestAdapter\Appveyor.TestLogger.TestAdapter.csproj"),(Join-Path $env:LE_ROOT_DIR "src\NUnit.Xml.TestLogger.TestAdapter\NUnit.Xml.TestLogger.TestAdapter.csproj"),(Join-Path $env:LE_ROOT_DIR "src\Xunit.Xml.TestLogger.TestAdapter\Xunit.Xml.TestLogger.TestAdapter.csproj")
-	
+
     ForEach ($proj in $LoggerProjects) {
         Write-Log ".. .. Build: $dotnetExe build $proj --configuration $LEB_Configuration -v:minimal -p:Version=$LEB_FullVersion"
         & $dotnetExe build $proj --configuration $LEB_Configuration -v:minimal -p:Version=$LEB_FullVersion
@@ -156,20 +156,20 @@ function Create-NugetPackages
     # Copy Appveyor Nunit and Nunit xml logger dll in Nuspec folder
     $sourceFile = Join-Path $env:LE_ROOT_DIR "src\Appveyor.TestLogger\bin\$LEB_Configuration\netstandard1.5\Microsoft.VisualStudio.TestPlatform.Extension.Appveyor.TestLogger.dll"
     Copy-Item $sourceFile $lePackageDirectory -Force
-	
+
 	$sourceFile = Join-Path $env:LE_ROOT_DIR "src\Appveyor.TestLogger.Testadapter\bin\$LEB_Configuration\netstandard1.5\Microsoft.VisualStudio.TestPlatform.Extension.Appveyor.TestAdapter.dll"
     Copy-Item $sourceFile $lePackageDirectory -Force
 
     $sourceFile = Join-Path $env:LE_ROOT_DIR "src\Xunit.Xml.TestLogger\bin\$LEB_Configuration\netstandard1.5\Microsoft.VisualStudio.TestPlatform.Extension.Xunit.Xml.TestLogger.dll"
     Copy-Item $sourceFile $lePackageDirectory -Force
-	
+
 	$sourceFile = Join-Path $env:LE_ROOT_DIR "src\Xunit.Xml.TestLogger.TestAdapter\bin\$LEB_Configuration\netstandard1.5\Microsoft.VisualStudio.TestPlatform.Extension.Xunit.Xml.TestAdapter.dll"
     Copy-Item $sourceFile $lePackageDirectory -Force
-	
-	$sourceFile = Join-Path $env:LE_ROOT_DIR "src\Nunit.Xml.TestLogger\bin\$LEB_Configuration\netstandard1.5\Microsoft.VisualStudio.TestPlatform.Extension.Nunit.Xml.TestLogger.dll"
+
+	$sourceFile = Join-Path $env:LE_ROOT_DIR "src\Nunit.Xml.TestLogger\bin\$LEB_Configuration\netstandard1.5\Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger.dll"
     Copy-Item $sourceFile $lePackageDirectory -Force
-	
-	$sourceFile = Join-Path $env:LE_ROOT_DIR "src\Nunit.Xml.TestLogger.TestAdapter\bin\$LEB_Configuration\netstandard1.5\Microsoft.VisualStudio.TestPlatform.Extension.Nunit.Xml.TestAdapter.dll"
+
+	$sourceFile = Join-Path $env:LE_ROOT_DIR "src\Nunit.Xml.TestLogger.TestAdapter\bin\$LEB_Configuration\netstandard1.5\Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestAdapter.dll"
     Copy-Item $sourceFile $lePackageDirectory -Force
 
     $nugetExe = Join-Path $env:LE_PACKAGES_DIR -ChildPath "Nuget.CommandLine" | Join-Path -ChildPath $env:NUGET_EXE_Version | Join-Path -ChildPath "tools\NuGet.exe"
@@ -180,7 +180,7 @@ function Create-NugetPackages
 
     Write-Log ".. .. Create-NugetPackages: $nugetExe pack $XunitXmlNuspecProject -OutputDirectory $lePackageDirectory -Version $LEB_FullVersion -Properties Version=$LEB_FullVersion"
     & $nugetExe pack $XunitXmlNuspecProject -OutputDirectory $lePackageDirectory -Version $LEB_FullVersion -Properties Version=$LEB_FullVersion
-	
+
 	Write-Log ".. .. Create-NugetPackages: $nugetExe pack $NunitXmlNuspecProject -OutputDirectory $lePackageDirectory -Version $LEB_FullVersion -Properties Version=$LEB_FullVersion"
     & $nugetExe pack $NunitXmlNuspecProject -OutputDirectory $lePackageDirectory -Version $LEB_FullVersion -Properties Version=$LEB_FullVersion
 
@@ -209,7 +209,7 @@ function Run-Test
     $testProject = Join-Path $TestProjectsDir "Appveyor.TestLogger.NetFull.Tests\Appveyor.TestLogger.NetFull.Tests.csproj"
     Write-Log ".. .. Run-Test: & $dotnetExe test $testProject --configuration:$LEB_Configuration --logger:Appveyor -p:LoggerVersion=$LEB_FullVersion"
     & $dotnetExe test $testProject --configuration:$LEB_Configuration --logger:Appveyor -p:LoggerVersion=$LEB_FullVersion
-	
+
     $testProject = Join-Path $TestProjectsDir "Xunit.Xml.TestLogger.NetCore.Tests\Xunit.Xml.TestLogger.NetCore.Tests.csproj"
     $loggerFilePath = Join-Path $TestProjectsDir "Xunit.Xml.TestLogger.NetCore.Tests\loggerFile.xml"
     Remove-Item $loggerFilePath -ErrorAction Ignore
@@ -298,7 +298,7 @@ function Set-ScriptFailed
 
 # Execute build
 $timer = Start-Timer
-New-Item -ItemType directory -Path (Join-Path $env:LE_ROOT_DIR "nugetPackage") -ErrorAction Ignore 
+New-Item -ItemType directory -Path (Join-Path $env:LE_ROOT_DIR "nugetPackage") -ErrorAction Ignore
 Write-Log "Build started: args = '$args'"
 Write-Log "Test platform environment variables: "
 Get-ChildItem env: | Where-Object -FilterScript { $_.Name.StartsWith("LE_") } | Format-Table
@@ -310,10 +310,10 @@ Invoke-Build
 Create-NugetPackages
 Run-Test
 Write-Log "Build complete. {$(Get-ElapsedTime($timer))}"
-if ($Script:ScriptFailed) { 
+if ($Script:ScriptFailed) {
     Write-Error "Build failed."
-    Exit 1 
-} else { 
+    Exit 1
+} else {
     Write-Log "Build success"
-    Exit 0 
+    Exit 0
 }


### PR DESCRIPTION
NUnit assemblies were packaged with incorrect case. On a case sensitive
platform, the build steps were not copying them to output directory.

Fixes https://github.com/Faizan2304/LoggerExtensions/issues/16