### PR TITLE
Add Support for targeting multiple frameworks using `dotnet test`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A path for the report file can be specified as follows:
 ```
 
 `loggerFile.xml` will be generated in the same directory as `test.csproj`.
+
 4. If you are targeting multiple frameworks in your `test.csproj`, you can enable `AppendTimeStamp` so that `LogFilePath` has `HH:mm:ss:ms` appended.
 ```
 > dotnet test --test-adapter-path:. --logger:nunit;LogFilePath=loggerFile.xml;AppendTimeStamp=true

--- a/README.md
+++ b/README.md
@@ -38,7 +38,12 @@ A path for the report file can be specified as follows:
 ```
 
 `loggerFile.xml` will be generated in the same directory as `test.csproj`.
- 
+4. If you are targeting multiple frameworks in your `test.csproj`, you can enable `AppendTimeStamp` so that `LogFilePath` has `HH:mm:ss:ms` appended.
+```
+> dotnet test --test-adapter-path:. --logger:nunit;LogFilePath=loggerFile.xml;AppendTimeStamp=true
+```
+`loggerFile-19:05:30:336.xml` will be generated for each target framework.
+
 ### Xunit Logger
 Xunit logger can generate xml reports in the xunit v2 format (https://xunit.github.io/docs/format-xml-v2.html).
 

--- a/src/NUnit.Xml.TestLogger/NUnitXmlTestLogger.cs
+++ b/src/NUnit.Xml.TestLogger/NUnitXmlTestLogger.cs
@@ -136,7 +136,7 @@
             // Append HH:mm:ss:ms to outputFilePath to ensure unique output filename
             // This is to prevent the output file from getting overwritten in the case of tests being ran for multiple target frameworks
             var filePathNoExtension = Path.ChangeExtension(filePath, null);
-            return $"{filePathNoExtension}{DateTime.Now.ToString("HH:mm:ss:ms")}.xml";
+            return $"{filePathNoExtension}-{DateTime.Now.ToString("HH:mm:ss:ms")}.xml";
         }
 
         private void InitializeImpl(TestLoggerEvents events, string outputPath)

--- a/src/NUnit.Xml.TestLogger/NUnitXmlTestLogger.cs
+++ b/src/NUnit.Xml.TestLogger/NUnitXmlTestLogger.cs
@@ -28,6 +28,8 @@
 
         public const string LogFilePathKey = "LogFilePath";
 
+        public const string AppendTimeStamp = "AppendTimeStamp";
+
         private const string ResultStatusPassed = "Passed";
         private const string ResultStatusFailed = "Failed";
 
@@ -113,6 +115,10 @@
 
             if (parameters.TryGetValue(LogFilePathKey, out string outputPath))
             {
+                if (parameters.TryGetValue(AppendTimeStamp, out appendTimeStamp))
+                {
+                    outputPath = AppendTimestampToXmlFile(outputPath);
+                }
                 InitializeImpl(events, outputPath);
             }
             else if (parameters.TryGetValue(DefaultLoggerParameterNames.TestRunDirectory, out string outputDir))
@@ -123,6 +129,14 @@
             {
                 throw new ArgumentException($"Expected {LogFilePathKey} or {DefaultLoggerParameterNames.TestRunDirectory} parameter", nameof(parameters));
             }
+        }
+
+        private string AppendTimestampToXmlFile(string filePath)
+        {
+            // Append HH:mm:ss:ms to outputFilePath to ensure unique output filename
+            // This is to prevent the output file from getting overwritten in the case of tests being ran for multiple target frameworks
+            var filePathNoExtension = Path.ChangeExtension(filePath, null);
+            return $"{filePathNoExtension}{DateTime.Now.ToString("HH:mm:ss:ms")}.xml";
         }
 
         private void InitializeImpl(TestLoggerEvents events, string outputPath)


### PR DESCRIPTION
This is a solution to #24, #27  