### PR TITLE
Add methodname and classname to test-case output

### DIFF
--- a/src/NUnit.Xml.TestLogger/NUnitXmlTestLogger.cs
+++ b/src/NUnit.Xml.TestLogger/NUnitXmlTestLogger.cs
@@ -377,6 +377,8 @@
             var element = new XElement("test-case",
                 new XAttribute("name", result.Name),
                 new XAttribute("fullname", result.Type + "." + result.Method),
+                new XAttribute("methodname", result.Method),
+                new XAttribute("classname", result.Type),
                 new XAttribute("result", OutcomeToString(result.Outcome)),
                 new XAttribute("duration", result.Time.TotalSeconds),
                 new XAttribute("asserts", 0));


### PR DESCRIPTION
Add methodname and classname to test-case output, which is closer to standard NUnit output and allows Jenkins to show correct namespace and class in test results (when used with dotnet vstest and Jenkinsfile 'nunit testResultsPattern')