### PR TITLE
feat: Include inconclusive tests count in test report.

### DIFF
--- a/test/NUnit.Xml.TestLogger.AcceptanceTests/NUnit.Xml.TestLogger.AcceptanceTests.csproj
+++ b/test/NUnit.Xml.TestLogger.AcceptanceTests/NUnit.Xml.TestLogger.AcceptanceTests.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
   <Target Name="TestTarget" AfterTargets="Build">
     <Message Importance="High" Text="... Building test assets" />
-    <RemoveDir Directories="$(NuGetPackageRoot)/xunitxml.testlogger" />
+    <RemoveDir Directories="$(NuGetPackageRoot)/nunitxml.testlogger" />
     <Exec ContinueOnError="False" Command="dotnet build -c $(Configuration) -p:RestoreConfigFile=$(TestRestoreConfig) -p:RestoreIgnoreFailedSources=true -p:RestoreNoCache=true $(TestCoreProject)"/>
     <Exec ContinueOnError="False" Command="dotnet build -c $(Configuration) -p:RestoreConfigFile=$(TestRestoreConfig) -p:RestoreIgnoreFailedSources=true -p:RestoreNoCache=true $(TestFullProject)"/>
     <Message Importance="High" Text="... Completed" />

--- a/test/NUnit.Xml.TestLogger.AcceptanceTests/NUnitXmlTestLoggerTests.cs
+++ b/test/NUnit.Xml.TestLogger.AcceptanceTests/NUnitXmlTestLoggerTests.cs
@@ -40,7 +40,8 @@ namespace NUnit.Xml.TestLogger.AcceptanceTests
             Assert.AreEqual("21", node.Attribute(XName.Get("testcasecount")).Value);
             Assert.AreEqual("7", node.Attribute(XName.Get("passed")).Value);
             Assert.AreEqual("7", node.Attribute(XName.Get("failed")).Value);
-            Assert.AreEqual("7", node.Attribute(XName.Get("skipped")).Value);
+            Assert.AreEqual("4", node.Attribute(XName.Get("inconclusive")).Value);
+            Assert.AreEqual("3", node.Attribute(XName.Get("skipped")).Value);
             Assert.AreEqual("Failed", node.Attribute(XName.Get("result")).Value);
 
             // Start time and End time should be valid dates
@@ -57,7 +58,8 @@ namespace NUnit.Xml.TestLogger.AcceptanceTests
             Assert.AreEqual("21", node.Attribute(XName.Get("total")).Value);
             Assert.AreEqual("7", node.Attribute(XName.Get("passed")).Value);
             Assert.AreEqual("7", node.Attribute(XName.Get("failed")).Value);
-            Assert.AreEqual("7", node.Attribute(XName.Get("skipped")).Value);
+            Assert.AreEqual("4", node.Attribute(XName.Get("inconclusive")).Value);
+            Assert.AreEqual("3", node.Attribute(XName.Get("skipped")).Value);
             Assert.AreEqual("Failed", node.Attribute(XName.Get("result")).Value);
             Assert.AreEqual("NUnit.Xml.TestLogger.NetCore.Tests.dll", node.Attribute(XName.Get("name")).Value);
             Assert.AreEqual(DotnetTestFixture.TestAssembly, node.Attribute(XName.Get("fullname")).Value);

--- a/test/assets/NUnit.Xml.TestLogger.NetCore.Tests/NUnit.Xml.TestLogger.NetCore.Tests.csproj
+++ b/test/assets/NUnit.Xml.TestLogger.NetCore.Tests/NUnit.Xml.TestLogger.NetCore.Tests.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="NUnit" Version="3.8.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
+    <PackageReference Include="NUnit" Version="3.10.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
     <PackageReference Include="NunitXml.TestLogger" Version="$(PackageVersion)" />
   </ItemGroup>
 


### PR DESCRIPTION
dotnet test reports both both inconclusive and explicittest annotated
tests as TestOutcome.None. Report both of these results as inconclusive
in the xml report. This is not entirely correct if user has both kinds of
tests, however it is slightly better than not including inconclusive tests
at all.

Fixes #31.