### PR TITLE
Missing test fixture results

### DIFF
--- a/src/NUnit.Xml.TestLogger.TestAdapter/NUnit.Xml.TestLogger.TestAdapter.csproj
+++ b/src/NUnit.Xml.TestLogger.TestAdapter/NUnit.Xml.TestLogger.TestAdapter.csproj
@@ -20,6 +20,7 @@
     <Compile Include="..\NUnit.Xml.TestLogger\StringExtensions.cs">
       <Link>StringExtensions.cs</Link>
     </Compile>
+    <Compile Include="..\NUnit.Xml.TestLogger\TestCaseNameParser.cs" Link="TestCaseNameParser.cs" />
     <Compile Include="..\NUnit.Xml.TestLogger\TestResultInfo.cs">
       <Link>TestResultInfo.cs</Link>
     </Compile>

--- a/src/NUnit.Xml.TestLogger/TestCaseNameParser.cs
+++ b/src/NUnit.Xml.TestLogger/TestCaseNameParser.cs
@@ -31,25 +31,22 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger
         }
 
         /// <summary>
-        /// This method attempts to parse out a Type and Method name from a given string. When a clearly
+        /// This method attempts to parse out a Namespace, Type and Method name from a given string. When a clearly
         /// invalid output is encountered, a message is written to the console.
         /// </summary>
         /// <remarks>
         /// This is fragile, because the fully qualified name is constructed by a test adapter and there is
-        /// no enforcement that the FQN starts with metadata type name, or is of the expected format.
+        /// no enforcement that the FQN starts with the namespace, or is of the expected format.
+        /// Because the possible input space is very large and this parser is relativly simple
+        /// there are some invalid strings, such as "#.#.#" will 'successfully' parse.
         /// </remarks>
-        /// <example>
-        /// Some invalid strings, such as "#.#" will 'successfully' parse, because the possible input space
-        /// is very large and this parser is relativly simple.
-        /// </example>
         /// <param name="fullyQualifedName">
-        /// String like 'type.method', where type and or method may be followed by parenthesis containing
-        /// parameter values. The string may be prefixed with namespaces.
+        /// String like 'namespace.type.method', where type and or method may be followed by parenthesis containing
+        /// parameter values.
         /// </param>
         /// <returns>
-        /// A Tuple of strings: typeName, methodName. Output will always be provided. In the case that
-        /// input was obviously invalid, then a string indicating the error will be the first value
-        /// and the input string will be the second.
+        /// An instance of ParsedName containing the parsed results. A result is always returned, even in the case when
+        /// the input could not be full parsed.
         /// </returns>
         public static ParsedName Parse(string fullyQualifedName)
         {

--- a/src/NUnit.Xml.TestLogger/TestCaseNameParser.cs
+++ b/src/NUnit.Xml.TestLogger/TestCaseNameParser.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Spekt Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Microsoft.VisualStudio.TestPlatform.Extension.JUnit.Xml.TestLogger
+namespace Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger
 {
     using System;
     using System.Collections.Generic;
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.JUnit.Xml.TestLogger
     {
         public const string TestCaseParserUnknownNamsepace = "UnknownNamespace";
         public const string TestCaseParserUnknownType = "UnknownType";
-        public const string TestCaseParserErrorTemplate = JUnitXmlTestLogger.FriendlyName + "Xml Logger: Unable to parse the test name '{0}' into a namespace type and method. " +
+        public const string TestCaseParserErrorTemplate = NUnitXmlTestLogger.FriendlyName + "Xml Logger: Unable to parse the test name '{0}' into a namespace type and method. " +
             "Using Namespace='{1}', Type='{2}' and Method='{3}'";
 
         private enum NameParseStep

--- a/src/NUnit.Xml.TestLogger/TestCaseNameParser.cs
+++ b/src/NUnit.Xml.TestLogger/TestCaseNameParser.cs
@@ -1,0 +1,234 @@
+﻿// Copyright (c) Spekt Contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+
+    public static class TestCaseNameParser
+    {
+        public const string TestCaseParserUnknownNamsepace = "UnknownNamespace";
+        public const string TestCaseParserUnknownType = "UnknownType";
+        public const string TestCaseParserErrorTemplate = NUnitXmlTestLogger.FriendlyName + "Xml Logger: Unable to parse the test name '{0}' into a namespace type and method. " +
+            "Using Namespace='{1}', Type='{2}' and Method='{3}'";
+
+        private enum NameParseStep
+        {
+            FindMethod,
+            FindType,
+            FindNamespace,
+            Done
+        }
+
+        private enum NameParseState
+        {
+            Default,
+            Parenthesis,
+            String
+        }
+
+        /// <summary>
+        /// This method attempts to parse out a Type and Method name from a given string. When a clearly
+        /// invalid output is encountered, a message is written to the console.
+        /// </summary>
+        /// <remarks>
+        /// This is fragile, because the fully qualified name is constructed by a test adapter and there is
+        /// no enforcement that the FQN starts with metadata type name, or is of the expected format.
+        /// </remarks>
+        /// <example>
+        /// Some invalid strings, such as "#.#" will 'successfully' parse, because the possible input space
+        /// is very large and this parser is relativly simple.
+        /// </example>
+        /// <param name="fullyQualifedName">
+        /// String like 'type.method', where type and or method may be followed by parenthesis containing
+        /// parameter values. The string may be prefixed with namespaces.
+        /// </param>
+        /// <returns>
+        /// A Tuple of strings: typeName, methodName. Output will always be provided. In the case that
+        /// input was obviously invalid, then a string indicating the error will be the first value
+        /// and the input string will be the second.
+        /// </returns>
+        public static ParsedName Parse(string fullyQualifedName)
+        {
+            var metadataNamespaceName = string.Empty;
+            var metadataTypeName = string.Empty;
+            var metadataMethodName = string.Empty;
+
+            var step = NameParseStep.FindMethod;
+            var state = NameParseState.Default;
+
+            var tuptuo = new List<char>();
+
+            try
+            {
+                var eman = fullyQualifedName.ToCharArray().Reverse().ToArray();
+
+                for (int i = 0; i < eman.Count(); i++)
+                {
+                    var thisChar = eman[i];
+                    if (step == NameParseStep.FindNamespace)
+                    {
+                        // When we are doing namespace, we always accumulate the char.
+                        tuptuo.Add(thisChar);
+                    }
+                    else if (state == NameParseState.Default)
+                    {
+                        if (thisChar == '(' || thisChar == '"' || thisChar == '\\')
+                        {
+                            throw new Exception("Found invalid characters");
+                        }
+                        else if (thisChar == ')')
+                        {
+                            if (tuptuo.Count > 0)
+                            {
+                                throw new Exception("The closing parenthesis we detected wouldn't be the last character in the output string. This isn't acceptable because we aren't in a string");
+                            }
+
+                            state = NameParseState.Parenthesis;
+                            tuptuo.Add(thisChar);
+                        }
+                        else if (thisChar == '.')
+                        {
+                            // Found the end of this element.
+                            if (step == NameParseStep.FindMethod)
+                            {
+                                if (tuptuo.Count == 0)
+                                {
+                                    throw new Exception("This shouldn't be an empty string");
+                                }
+
+                                tuptuo.Reverse();
+                                metadataMethodName = string.Join(string.Empty, tuptuo);
+
+                                // Prep the next step
+                                tuptuo = new List<char>();
+                                step = NameParseStep.FindType;
+                            }
+                            else if (step == NameParseStep.FindType)
+                            {
+                                if (tuptuo.Count == 0)
+                                {
+                                    throw new Exception("This shouldn't be an empty string");
+                                }
+
+                                tuptuo.Reverse();
+                                metadataTypeName = string.Join(string.Empty, tuptuo);
+
+                                // Get The Namespace Next
+                                step = NameParseStep.FindNamespace;
+                                tuptuo = new List<char>();
+                            }
+                        }
+                        else
+                        {
+                            // Part of the name to add
+                            tuptuo.Add(thisChar);
+                        }
+                    }
+                    else if (state == NameParseState.Parenthesis)
+                    {
+                        if (thisChar == ')' || thisChar == '\\')
+                        {
+                            throw new Exception("Found invalid characters");
+                        }
+                        else if (thisChar == '(')
+                        {
+                            // If we found the beginning of the parenthesis block, we are back in default state
+                            state = NameParseState.Default;
+                            tuptuo.Add(thisChar);
+                        }
+                        else if (thisChar == '"')
+                        {
+                            // This must come at the end of a string, when escape characters aren't an issue, so we are
+                            // 'entering' string state, because of the reverse parsing.
+                            state = NameParseState.String;
+                            tuptuo.Add(thisChar);
+                        }
+                        else
+                        {
+                            tuptuo.Add(thisChar);
+                        }
+                    }
+                    else
+                    {
+                        // We are in String State.
+                        if (thisChar == '"')
+                        {
+                            if (eman.ElementAtOrDefault(i + 1) == '\\')
+                            {
+                                // The quote was escaped, so its atually a quote mark in a string
+                                tuptuo.Add(thisChar);
+                            }
+                            else
+                            {
+                                state = NameParseState.Parenthesis;
+                                tuptuo.Add(thisChar);
+                            }
+                        }
+                        else
+                        {
+                            tuptuo.Add(thisChar);
+                        }
+                    }
+                }
+
+                // We are done. If we are finding type, set that variable.
+                // Otherwise, ther was some issue, so leave the type blank.
+                if (step == NameParseStep.FindNamespace)
+                {
+                    tuptuo.Reverse();
+                    metadataNamespaceName = string.Join(string.Empty, tuptuo);
+                }
+                else if (step == NameParseStep.FindType)
+                {
+                    tuptuo.Reverse();
+                    metadataTypeName = string.Join(string.Empty, tuptuo);
+                }
+            }
+            catch (Exception)
+            {
+                // On exception, whipe out the type name
+                metadataTypeName = string.Empty;
+                metadataNamespaceName = string.Empty;
+            }
+            finally
+            {
+                // If for any reason we don't have a Type Name or Namespace then
+                // we fall back on our safe option and notify the user
+                if (string.IsNullOrWhiteSpace(metadataNamespaceName) && string.IsNullOrWhiteSpace(metadataTypeName))
+                {
+                    metadataNamespaceName = TestCaseParserUnknownNamsepace;
+                    metadataTypeName = TestCaseParserUnknownType;
+                    metadataMethodName = fullyQualifedName;
+                    Console.WriteLine(string.Format(TestCaseParserErrorTemplate, fullyQualifedName, metadataNamespaceName, metadataTypeName, metadataMethodName));
+                }
+                else if (string.IsNullOrWhiteSpace(metadataNamespaceName))
+                {
+                    metadataNamespaceName = TestCaseParserUnknownNamsepace;
+                    Console.WriteLine(string.Format(TestCaseParserErrorTemplate, fullyQualifedName, metadataNamespaceName, metadataTypeName, metadataMethodName));
+                }
+            }
+
+            return new ParsedName(metadataNamespaceName, metadataTypeName, metadataMethodName);
+        }
+
+        public class ParsedName
+        {
+            public ParsedName(string namespaceName, string typeName, string methodName)
+            {
+                this.NamespaceName = namespaceName;
+                this.TypeName = typeName;
+                this.MethodName = methodName;
+            }
+
+            public string NamespaceName { get; }
+
+            public string TypeName { get; }
+
+            public string MethodName { get; }
+        }
+    }
+}

--- a/src/NUnit.Xml.TestLogger/TestCaseNameParser.cs
+++ b/src/NUnit.Xml.TestLogger/TestCaseNameParser.cs
@@ -1,7 +1,7 @@
-﻿// Copyright (c) Spekt Contributors. All rights reserved.
+// Copyright (c) Spekt Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger
+namespace Microsoft.VisualStudio.TestPlatform.Extension.JUnit.Xml.TestLogger
 {
     using System;
     using System.Collections.Generic;
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger
     {
         public const string TestCaseParserUnknownNamsepace = "UnknownNamespace";
         public const string TestCaseParserUnknownType = "UnknownType";
-        public const string TestCaseParserErrorTemplate = NUnitXmlTestLogger.FriendlyName + "Xml Logger: Unable to parse the test name '{0}' into a namespace type and method. " +
+        public const string TestCaseParserErrorTemplate = JUnitXmlTestLogger.FriendlyName + "Xml Logger: Unable to parse the test name '{0}' into a namespace type and method. " +
             "Using Namespace='{1}', Type='{2}' and Method='{3}'";
 
         private enum NameParseStep
@@ -57,19 +57,17 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger
             var step = NameParseStep.FindMethod;
             var state = NameParseState.Default;
 
-            var tuptuo = new List<char>();
+            var output = new List<char>();
 
             try
             {
-                var eman = fullyQualifedName.ToCharArray().Reverse().ToArray();
-
-                for (int i = 0; i < eman.Count(); i++)
+                for (int i = fullyQualifedName.Length - 1; i >= 0; i--)
                 {
-                    var thisChar = eman[i];
+                    var thisChar = fullyQualifedName[i];
                     if (step == NameParseStep.FindNamespace)
                     {
                         // When we are doing namespace, we always accumulate the char.
-                        tuptuo.Add(thisChar);
+                        output.Insert(0, thisChar);
                     }
                     else if (state == NameParseState.Default)
                     {
@@ -79,50 +77,48 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger
                         }
                         else if (thisChar == ')')
                         {
-                            if (tuptuo.Count > 0)
+                            if (output.Count > 0)
                             {
                                 throw new Exception("The closing parenthesis we detected wouldn't be the last character in the output string. This isn't acceptable because we aren't in a string");
                             }
 
                             state = NameParseState.Parenthesis;
-                            tuptuo.Add(thisChar);
+                            output.Insert(0, thisChar);
                         }
                         else if (thisChar == '.')
                         {
                             // Found the end of this element.
                             if (step == NameParseStep.FindMethod)
                             {
-                                if (tuptuo.Count == 0)
+                                if (output.Count == 0)
                                 {
                                     throw new Exception("This shouldn't be an empty string");
                                 }
 
-                                tuptuo.Reverse();
-                                metadataMethodName = string.Join(string.Empty, tuptuo);
+                                metadataMethodName = string.Join(string.Empty, output);
 
                                 // Prep the next step
-                                tuptuo = new List<char>();
+                                output = new List<char>();
                                 step = NameParseStep.FindType;
                             }
                             else if (step == NameParseStep.FindType)
                             {
-                                if (tuptuo.Count == 0)
+                                if (output.Count == 0)
                                 {
                                     throw new Exception("This shouldn't be an empty string");
                                 }
 
-                                tuptuo.Reverse();
-                                metadataTypeName = string.Join(string.Empty, tuptuo);
+                                metadataTypeName = string.Join(string.Empty, output);
 
                                 // Get The Namespace Next
                                 step = NameParseStep.FindNamespace;
-                                tuptuo = new List<char>();
+                                output = new List<char>();
                             }
                         }
                         else
                         {
                             // Part of the name to add
-                            tuptuo.Add(thisChar);
+                            output.Insert(0, thisChar);
                         }
                     }
                     else if (state == NameParseState.Parenthesis)
@@ -131,44 +127,33 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger
                         {
                             throw new Exception("Found invalid characters");
                         }
-                        else if (thisChar == '(')
+
+                        if (thisChar == '(')
                         {
                             // If we found the beginning of the parenthesis block, we are back in default state
                             state = NameParseState.Default;
-                            tuptuo.Add(thisChar);
                         }
                         else if (thisChar == '"')
                         {
                             // This must come at the end of a string, when escape characters aren't an issue, so we are
                             // 'entering' string state, because of the reverse parsing.
                             state = NameParseState.String;
-                            tuptuo.Add(thisChar);
                         }
-                        else
-                        {
-                            tuptuo.Add(thisChar);
-                        }
+
+                        output.Insert(0, thisChar);
                     }
+
+                    // state == NameParseState.String
                     else
                     {
-                        // We are in String State.
-                        if (thisChar == '"')
+                        if (thisChar == '"' && fullyQualifedName.ElementAtOrDefault(i - 1) != '\\')
                         {
-                            if (eman.ElementAtOrDefault(i + 1) == '\\')
-                            {
-                                // The quote was escaped, so its atually a quote mark in a string
-                                tuptuo.Add(thisChar);
-                            }
-                            else
-                            {
-                                state = NameParseState.Parenthesis;
-                                tuptuo.Add(thisChar);
-                            }
+                            // If this is a quote that has not been escaped, switch the state. If it had
+                            // been escaped, we would still be in a string.
+                            state = NameParseState.Parenthesis;
                         }
-                        else
-                        {
-                            tuptuo.Add(thisChar);
-                        }
+
+                        output.Insert(0, thisChar);
                     }
                 }
 
@@ -176,18 +161,16 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger
                 // Otherwise, ther was some issue, so leave the type blank.
                 if (step == NameParseStep.FindNamespace)
                 {
-                    tuptuo.Reverse();
-                    metadataNamespaceName = string.Join(string.Empty, tuptuo);
+                    metadataNamespaceName = string.Join(string.Empty, output);
                 }
                 else if (step == NameParseStep.FindType)
                 {
-                    tuptuo.Reverse();
-                    metadataTypeName = string.Join(string.Empty, tuptuo);
+                    metadataTypeName = string.Join(string.Empty, output);
                 }
             }
             catch (Exception)
             {
-                // On exception, whipe out the type name
+                // On exception, wipe out the type name
                 metadataTypeName = string.Empty;
                 metadataNamespaceName = string.Empty;
             }

--- a/src/NUnit.Xml.TestLogger/TestResultInfo.cs
+++ b/src/NUnit.Xml.TestLogger/TestResultInfo.cs
@@ -13,10 +13,12 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger
 
         public TestResultInfo(
             TestResult result,
+            string @namespace,
             string type,
             string method)
         {
             this.result = result;
+            this.Namespace = @namespace;
             this.Type = type;
             this.Method = method;
         }
@@ -27,7 +29,11 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger
 
         public string AssemblyPath => result.TestCase.Source;
 
+        public string Namespace { get; private set; }
+
         public string Type { get; private set; }
+
+        public string FullTypeName => Namespace + "." + Type;
 
         public string Method { get; private set; }
 

--- a/test/NUnit.Xml.TestLogger.AcceptanceTests/NUnitTestLoggerAcceptanceTests.cs
+++ b/test/NUnit.Xml.TestLogger.AcceptanceTests/NUnitTestLoggerAcceptanceTests.cs
@@ -40,8 +40,8 @@ namespace NUnit.Xml.TestLogger.AcceptanceTests
             var node = this.resultsXml.XPathSelectElement("/test-run");
 
             Assert.IsNotNull(node);
-            Assert.AreEqual("48", node.Attribute(XName.Get("testcasecount")).Value);
-            Assert.AreEqual("20", node.Attribute(XName.Get("passed")).Value);
+            Assert.AreEqual("52", node.Attribute(XName.Get("testcasecount")).Value);
+            Assert.AreEqual("24", node.Attribute(XName.Get("passed")).Value);
             Assert.AreEqual("14", node.Attribute(XName.Get("failed")).Value);
             Assert.AreEqual("8", node.Attribute(XName.Get("inconclusive")).Value);
             Assert.AreEqual("6", node.Attribute(XName.Get("skipped")).Value);
@@ -58,8 +58,8 @@ namespace NUnit.Xml.TestLogger.AcceptanceTests
             var node = this.resultsXml.XPathSelectElement("/test-run/test-suite[@type='Assembly']");
 
             Assert.IsNotNull(node);
-            Assert.AreEqual("48", node.Attribute(XName.Get("total")).Value);
-            Assert.AreEqual("20", node.Attribute(XName.Get("passed")).Value);
+            Assert.AreEqual("52", node.Attribute(XName.Get("total")).Value);
+            Assert.AreEqual("24", node.Attribute(XName.Get("passed")).Value);
             Assert.AreEqual("14", node.Attribute(XName.Get("failed")).Value);
             Assert.AreEqual("8", node.Attribute(XName.Get("inconclusive")).Value);
             Assert.AreEqual("6", node.Attribute(XName.Get("skipped")).Value);
@@ -77,8 +77,8 @@ namespace NUnit.Xml.TestLogger.AcceptanceTests
             var node = this.resultsXml.XPathSelectElement(query);
 
             Assert.IsNotNull(node);
-            Assert.AreEqual("27", node.Attribute(XName.Get("total")).Value);
-            Assert.AreEqual("13", node.Attribute(XName.Get("passed")).Value);
+            Assert.AreEqual("29", node.Attribute(XName.Get("total")).Value);
+            Assert.AreEqual("15", node.Attribute(XName.Get("passed")).Value);
             Assert.AreEqual("7", node.Attribute(XName.Get("failed")).Value);
             Assert.AreEqual("4", node.Attribute(XName.Get("inconclusive")).Value);
             Assert.AreEqual("3", node.Attribute(XName.Get("skipped")).Value);
@@ -95,8 +95,8 @@ namespace NUnit.Xml.TestLogger.AcceptanceTests
             var node = this.resultsXml.XPathSelectElement(query);
 
             Assert.IsNotNull(node);
-            Assert.AreEqual("21", node.Attribute(XName.Get("total")).Value);
-            Assert.AreEqual("7", node.Attribute(XName.Get("passed")).Value);
+            Assert.AreEqual("23", node.Attribute(XName.Get("total")).Value);
+            Assert.AreEqual("9", node.Attribute(XName.Get("passed")).Value);
             Assert.AreEqual("7", node.Attribute(XName.Get("failed")).Value);
             Assert.AreEqual("4", node.Attribute(XName.Get("inconclusive")).Value);
             Assert.AreEqual("3", node.Attribute(XName.Get("skipped")).Value);

--- a/test/NUnit.Xml.TestLogger.UnitTests/TestCaseNameParserTests.cs
+++ b/test/NUnit.Xml.TestLogger.UnitTests/TestCaseNameParserTests.cs
@@ -1,0 +1,117 @@
+﻿// Copyright (c) Spekt Contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace NUnit.Xml.TestLogger.UnitTests
+{
+    using System;
+    using System.IO;
+    using Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class TestCaseNameParserTests
+    {
+        [DataTestMethod]
+        [DataRow("z.a.b", "z", "a", "b")]
+
+        // Cover all expected cases of different parentesis locations, handling normal strings
+        [DataRow("z.y.x.a.b(\"arg\",2)", "z.y.x", "a", "b(\"arg\",2)")]
+        [DataRow("z.y.x.a(\"arg\",2).b", "z.y.x", "a(\"arg\",2)", "b")]
+        [DataRow("z.y.x.a(\"arg\",2).b(\"arg\",2)", "z.y.x", "a(\"arg\",2)", "b(\"arg\",2)")]
+        [DataRow("z.y.x.a(\"arg.())(\",2).b", "z.y.x", "a(\"arg.())(\",2)", "b")]
+
+        // Cover select cases with characters in strings that could cause issues
+        [DataRow("z.y.x.a.b(\"arg\",\"\\\"\")", "z.y.x", "a", "b(\"arg\",\"\\\"\")")]
+        [DataRow("z.y.x.a.b(\"arg\",\")(\")", "z.y.x", "a", "b(\"arg\",\")(\")")]
+
+        // Tests with longer type and method names
+        [DataRow("z.y.x.ape.bar(\"ar.g\",\"\\\"\")", "z.y.x", "ape", "bar(\"ar.g\",\"\\\"\")")]
+        [DataRow("z.y.x.ape.bar(\"ar.g\",\")(\")", "z.y.x", "ape", "bar(\"ar.g\",\")(\")")]
+        public void Parse_ParsesAllParsableInputs_WithoutConsoleOutput(string testCaseName, string expectedNamespace, string expectedType, string expectedMethod)
+        {
+            var expected = new Tuple<string, string>(expectedType, expectedMethod);
+
+            using (var sw = new StringWriter())
+            {
+                Console.SetOut(sw);
+                var actual = TestCaseNameParser.Parse(testCaseName);
+
+                Assert.AreEqual(expectedNamespace, actual.NamespaceName);
+                Assert.AreEqual(expectedType, actual.TypeName);
+                Assert.AreEqual(expectedMethod, actual.MethodName);
+                Assert.AreEqual(0, sw.ToString().Length);
+            }
+        }
+
+        [DataTestMethod]
+        [DataRow("a.b", TestCaseNameParser.TestCaseParserUnknownNamsepace, "a", "b")]
+
+        // Cover all expected cases of different parentesis locations, handling normal strings
+        [DataRow("a.b(\"arg\",2)", TestCaseNameParser.TestCaseParserUnknownNamsepace, "a", "b(\"arg\",2)")]
+        [DataRow("a(\"arg\",2).b", TestCaseNameParser.TestCaseParserUnknownNamsepace, "a(\"arg\",2)", "b")]
+        [DataRow("a(\"arg\",2).b(\"arg\",2)", TestCaseNameParser.TestCaseParserUnknownNamsepace, "a(\"arg\",2)", "b(\"arg\",2)")]
+
+        // Examples with period in non string
+        [DataRow("a.b(0.5f)", TestCaseNameParser.TestCaseParserUnknownNamsepace, "a", "b(0.5f)")]
+        public void Parse_ParsesAllParsableInputsWithoutNamespace_WithConsoleOutput(string testCaseName, string expectedNamespace, string expectedType, string expectedMethod)
+        {
+            var expectedConsole = string.Format(
+                    TestCaseNameParser.TestCaseParserErrorTemplate,
+                    testCaseName,
+                    expectedNamespace,
+                    expectedType,
+                    expectedMethod);
+
+            using (var sw = new StringWriter())
+            {
+                Console.SetOut(sw);
+                var actual = TestCaseNameParser.Parse(testCaseName);
+
+                Assert.AreEqual(expectedNamespace, actual.NamespaceName);
+                Assert.AreEqual(expectedType, actual.TypeName);
+                Assert.AreEqual(expectedMethod, actual.MethodName);
+
+                // Remove the trailing new line before comparing.
+                Assert.AreEqual(expectedConsole, sw.ToString().Replace(sw.NewLine, string.Empty));
+            }
+        }
+
+        [DataTestMethod]
+        [DataRow("x.()x()")]
+        [DataRow("x")]
+        [DataRow("z.y.X(x")]
+        [DataRow("z.y.x(")]
+        [DataRow("z.y.X\"x")]
+        [DataRow("z.y.x\"")]
+        [DataRow("z.y.X\\x")]
+        [DataRow("z.y.x\\")]
+        [DataRow("z.y.X\\)")]
+        [DataRow("z.y.x))")]
+        [DataRow("z.y.x()x")]
+        [DataRow("z.y.x.")]
+        [DataRow("z.y.x.)")]
+        [DataRow("z.y.x.\"\")")]
+        public void Parse_FailsGracefullyOnNonParsableInputs_WithConsoleOutput(string testCaseName)
+        {
+            var expectedConsole = string.Format(
+                TestCaseNameParser.TestCaseParserErrorTemplate,
+                testCaseName,
+                TestCaseNameParser.TestCaseParserUnknownNamsepace,
+                TestCaseNameParser.TestCaseParserUnknownType,
+                testCaseName);
+
+            using (var sw = new StringWriter())
+            {
+                Console.SetOut(sw);
+                var actual = TestCaseNameParser.Parse(testCaseName);
+
+                Assert.AreEqual(TestCaseNameParser.TestCaseParserUnknownNamsepace, actual.NamespaceName);
+                Assert.AreEqual(TestCaseNameParser.TestCaseParserUnknownType, actual.TypeName);
+                Assert.AreEqual(testCaseName, actual.MethodName);
+
+                // Remove the trailing new line before comparing.
+                Assert.AreEqual(expectedConsole, sw.ToString().Replace(sw.NewLine, string.Empty));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Pulled in updated test name parse. Looks like this is now picking up the tests with fixture data. 