### PR TITLE
Add start-time and end-time attributes to test-cases and test-suites

### DIFF
--- a/src/NUnit.Xml.TestLogger/NUnitXmlTestLogger.cs
+++ b/src/NUnit.Xml.TestLogger/NUnitXmlTestLogger.cs
@@ -215,6 +215,8 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger
             int inconclusive = 0;
             int error = 0;
             var time = TimeSpan.Zero;
+            DateTime? startTime = null;
+            DateTime? endTime = null;
 
             foreach (var result in suites)
             {
@@ -225,6 +227,16 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger
                 inconclusive += result.Inconclusive;
                 error += result.Error;
                 time += result.Time;
+
+                if (result.StartTime.HasValue && (!startTime.HasValue || result.StartTime.Value < startTime.Value))
+                {
+                    startTime = result.StartTime;
+                }
+
+                if (result.EndTime.HasValue && (!endTime.HasValue || result.EndTime.Value > endTime.Value))
+                {
+                    endTime = result.EndTime;
+                }
 
                 element.Add(result.Element);
             }
@@ -240,6 +252,17 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger
 
             var resultString = failed > 0 ? ResultStatusFailed : ResultStatusPassed;
             element.SetAttributeValue("result", resultString);
+
+            if (startTime.HasValue)
+            {
+                element.SetAttributeValue("start-time", startTime.Value);
+            }
+
+            if (endTime.HasValue)
+            {
+                element.SetAttributeValue("end-time", endTime.Value);
+            }
+
             element.SetAttributeValue("duration", time.TotalSeconds);
 
             return new TestSuite
@@ -253,6 +276,8 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger
                 Inconclusive = inconclusive,
                 Skipped = skipped,
                 Error = error,
+                StartTime = startTime,
+                EndTime = endTime,
                 Time = time
             };
         }
@@ -268,6 +293,8 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger
             int inconclusive = 0;
             int error = 0;
             var time = TimeSpan.Zero;
+            DateTime? startTime = null;
+            DateTime? endTime = null;
 
             foreach (var result in resultsByType)
             {
@@ -292,6 +319,16 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger
                 total++;
                 time += result.Duration;
 
+                if (!startTime.HasValue || result.StartTime < startTime)
+                {
+                    startTime = result.StartTime;
+                }
+
+                if (!endTime.HasValue || result.EndTime > endTime)
+                {
+                    endTime = result.EndTime;
+                }
+
                 // Create test-case elements
                 element.Add(CreateTestCaseElement(result));
             }
@@ -311,6 +348,17 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger
 
             var resultString = failed > 0 ? ResultStatusFailed : ResultStatusPassed;
             element.SetAttributeValue("result", resultString);
+
+            if (startTime.HasValue)
+            {
+                element.SetAttributeValue("start-time", startTime.Value);
+            }
+
+            if (endTime.HasValue)
+            {
+                element.SetAttributeValue("end-time", endTime);
+            }
+
             element.SetAttributeValue("duration", time.TotalSeconds);
 
             return new TestSuite
@@ -324,6 +372,8 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger
                 Inconclusive = inconclusive,
                 Skipped = skipped,
                 Error = error,
+                StartTime = startTime,
+                EndTime = endTime,
                 Time = time
             };
         }
@@ -337,6 +387,8 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger
                 new XAttribute("methodname", result.Method),
                 new XAttribute("classname", result.Type),
                 new XAttribute("result", OutcomeToString(result.Outcome)),
+                new XAttribute("start-time", result.StartTime),
+                new XAttribute("end-time", result.EndTime),
                 new XAttribute("duration", result.Duration.TotalSeconds),
                 new XAttribute("asserts", 0),
                 CreatePropertiesElement(result.TestCase));
@@ -531,6 +583,10 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger
             public int Error { get; set; }
 
             public TimeSpan Time { get; set; }
+
+            public DateTime? StartTime { get; set; }
+
+            public DateTime? EndTime { get; set; }
         }
     }
 }

--- a/src/NUnit.Xml.TestLogger/NUnitXmlTestLogger.cs
+++ b/src/NUnit.Xml.TestLogger/NUnitXmlTestLogger.cs
@@ -255,12 +255,12 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger
 
             if (startTime.HasValue)
             {
-                element.SetAttributeValue("start-time", startTime.Value);
+                element.SetAttributeValue("start-time", startTime.Value.ToString(DateFormat, CultureInfo.InvariantCulture));
             }
 
             if (endTime.HasValue)
             {
-                element.SetAttributeValue("end-time", endTime.Value);
+                element.SetAttributeValue("end-time", endTime.Value.ToString(DateFormat, CultureInfo.InvariantCulture));
             }
 
             element.SetAttributeValue("duration", time.TotalSeconds);
@@ -351,12 +351,12 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger
 
             if (startTime.HasValue)
             {
-                element.SetAttributeValue("start-time", startTime.Value);
+                element.SetAttributeValue("start-time", startTime.Value.ToString(DateFormat, CultureInfo.InvariantCulture));
             }
 
             if (endTime.HasValue)
             {
-                element.SetAttributeValue("end-time", endTime);
+                element.SetAttributeValue("end-time", endTime.Value.ToString(DateFormat, CultureInfo.InvariantCulture));
             }
 
             element.SetAttributeValue("duration", time.TotalSeconds);
@@ -387,8 +387,8 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger
                 new XAttribute("methodname", result.Method),
                 new XAttribute("classname", result.Type),
                 new XAttribute("result", OutcomeToString(result.Outcome)),
-                new XAttribute("start-time", result.StartTime),
-                new XAttribute("end-time", result.EndTime),
+                new XAttribute("start-time", result.StartTime.ToString(DateFormat, CultureInfo.InvariantCulture)),
+                new XAttribute("end-time", result.EndTime.ToString(DateFormat, CultureInfo.InvariantCulture)),
                 new XAttribute("duration", result.Duration.TotalSeconds),
                 new XAttribute("asserts", 0),
                 CreatePropertiesElement(result.TestCase));

--- a/src/NUnit.Xml.TestLogger/TestResultInfo.cs
+++ b/src/NUnit.Xml.TestLogger/TestResultInfo.cs
@@ -39,6 +39,10 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger
 
         public string Name => result.TestCase.DisplayName;
 
+        public DateTime StartTime => result.StartTime.UtcDateTime;
+
+        public DateTime EndTime => result.EndTime.UtcDateTime;
+
         public TimeSpan Duration => result.Duration;
 
         public string ErrorMessage => result.ErrorMessage;

--- a/test/NUnit.Xml.TestLogger.AcceptanceTests/NUnitTestLoggerAcceptanceTests.cs
+++ b/test/NUnit.Xml.TestLogger.AcceptanceTests/NUnitTestLoggerAcceptanceTests.cs
@@ -67,6 +67,15 @@ namespace NUnit.Xml.TestLogger.AcceptanceTests
             Assert.AreEqual("Failed", node.Attribute(XName.Get("result")).Value);
             Assert.AreEqual("NUnit.Xml.TestLogger.NetCore.Tests.dll", node.Attribute(XName.Get("name")).Value);
             Assert.AreEqual(DotnetTestFixture.TestAssembly, node.Attribute(XName.Get("fullname")).Value);
+
+            var startTimeStr = node.Attribute(XName.Get("start-time"))?.Value;
+            var endTimeStr = node.Attribute(XName.Get("end-time"))?.Value;
+            Assert.IsNotNull(startTimeStr);
+            Assert.IsNotNull(endTimeStr);
+
+            var startTime = Convert.ToDateTime(startTimeStr);
+            var endTime = Convert.ToDateTime(endTimeStr);
+            Assert.IsTrue(startTime < endTime, "test suite start time should be before end time");
         }
 
         [TestMethod]

--- a/test/assets/NUnit.Xml.TestLogger.NetCore.Tests/UnitTest1.cs
+++ b/test/assets/NUnit.Xml.TestLogger.NetCore.Tests/UnitTest1.cs
@@ -11,7 +11,7 @@ namespace NUnit.Xml.TestLogger.NetFull.Tests
         [Description("Passing test description")]
         public async Task PassTest11()
         {
-            await Task.Delay(TimeSpan.FromMilliseconds(400));
+            await Task.Delay(TimeSpan.FromMilliseconds(1200));
         }
 
         [Test]

--- a/test/assets/NUnit.Xml.TestLogger.NetCore.Tests/UnitTest2.cs
+++ b/test/assets/NUnit.Xml.TestLogger.NetCore.Tests/UnitTest2.cs
@@ -11,7 +11,7 @@ namespace NUnit.Xml.TestLogger.Tests2
         [Description("Passing test description")]
         public async Task PassTest11()
         {
-            await Task.Delay(TimeSpan.FromMilliseconds(400));
+            await Task.Delay(TimeSpan.FromMilliseconds(1200));
         }
 
         [Test]


### PR DESCRIPTION
This PR adds the start-time and end-time attributes specified in the NUnit XML schema to test-case and test-suite elements. I did not find a reasonable way to accurately get test suite start and end times from the test framework, so those properties are aggregated based on their contained cases' or suites' start and end times.