### PR TITLE
chore: update dependencies to .net core 3.0 sdk.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,5 @@
 version: '2.1.{build}'
-image: Visual Studio 2017
+image: Visual Studio 2019
 
 clone_depth: 1
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: csharp
 
 matrix:
     include:
-        - dotnet: 2.1
+        - dotnet: 3.1
           mono: latest
 
 solution: nunit.testlogger.sln

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## Unreleased
+
+* Update toolset to dotnet 3.0
+* Fix missing test cases due to brackets. See
+  https://github.com/spekt/nunit.testlogger/issues/57
+* Support for `--results-directory` in dotnet test. See
+  https://github.com/spekt/nunit.testlogger/issues/46
+
+## v2.1.41 - 2019/05/20

--- a/src/package/package.csproj
+++ b/src/package/package.csproj
@@ -28,7 +28,7 @@
     <CopyOutputSymbolsToPublishDirectory>false</CopyOutputSymbolsToPublishDirectory>
 
     <!-- Disable warning that there are no source files. It is intentional. -->
-    <NoWarn>$(NoWarn);2008</NoWarn>
+    <NoWarn>$(NoWarn);2008;NU5127</NoWarn>
 
     <!-- Nuget pack configuration -->
     <NuspecFile>bin\$(Configuration)\$(TargetFramework)\NUnitXml.TestLogger.nuspec</NuspecFile>

--- a/test/NUnit.Xml.TestLogger.AcceptanceTests/DotnetTestFixture.cs
+++ b/test/NUnit.Xml.TestLogger.AcceptanceTests/DotnetTestFixture.cs
@@ -30,7 +30,7 @@ namespace NUnit.Xml.TestLogger.AcceptanceTests
 #else
                 var config = "Release";
 #endif
-                return Path.Combine(RootDirectory, "bin", config, "netcoreapp2.0", TestAssemblyName);
+                return Path.Combine(RootDirectory, "bin", config, "netcoreapp3.0", TestAssemblyName);
             }
         }
 
@@ -55,7 +55,7 @@ namespace NUnit.Xml.TestLogger.AcceptanceTests
             // Log the contents of test output directory. Useful to verify if the logger is copied
             Console.WriteLine("------------");
             Console.WriteLine("Contents of test output directory:");
-            foreach (var f in Directory.GetFiles(Path.Combine(testProject, "bin/Debug/netcoreapp2.0")))
+            foreach (var f in Directory.GetFiles(Path.Combine(testProject, "bin/Debug/netcoreapp3.0")))
             {
                 Console.WriteLine("  " + f);
             }
@@ -88,8 +88,9 @@ namespace NUnit.Xml.TestLogger.AcceptanceTests
 
             // Log the contents of test output directory. Useful to verify if the logger is copied
             Console.WriteLine("------------");
+            Console.WriteLine($"Current directory: {Environment.CurrentDirectory}");
             Console.WriteLine("Contents of test output directory:");
-            foreach (var f in Directory.GetFiles(Path.Combine(testProject, "bin/Debug/netcoreapp2.0")))
+            foreach (var f in Directory.GetFiles(Path.Combine(testProject, "bin/Debug/netcoreapp3.0")))
             {
                 Console.WriteLine("  " + f);
             }

--- a/test/NUnit.Xml.TestLogger.AcceptanceTests/NUnit.Xml.TestLogger.AcceptanceTests.csproj
+++ b/test/NUnit.Xml.TestLogger.AcceptanceTests/NUnit.Xml.TestLogger.AcceptanceTests.csproj
@@ -7,7 +7,7 @@
   <Import Project="$(SourceRoot)scripts/settings.targets" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <WarningsAsErrors>true</WarningsAsErrors>
     <EnableCodeAnalysis>true</EnableCodeAnalysis>
     <IsPackable>false</IsPackable>

--- a/test/NUnit.Xml.TestLogger.AcceptanceTests/NUnitTestLoggerAcceptanceTests.cs
+++ b/test/NUnit.Xml.TestLogger.AcceptanceTests/NUnitTestLoggerAcceptanceTests.cs
@@ -40,8 +40,8 @@ namespace NUnit.Xml.TestLogger.AcceptanceTests
             var node = this.resultsXml.XPathSelectElement("/test-run");
 
             Assert.IsNotNull(node);
-            Assert.AreEqual("53", node.Attribute(XName.Get("testcasecount")).Value);
-            Assert.AreEqual("25", node.Attribute(XName.Get("passed")).Value);
+            Assert.AreEqual("52", node.Attribute(XName.Get("testcasecount")).Value);
+            Assert.AreEqual("24", node.Attribute(XName.Get("passed")).Value);
             Assert.AreEqual("14", node.Attribute(XName.Get("failed")).Value);
             Assert.AreEqual("8", node.Attribute(XName.Get("inconclusive")).Value);
             Assert.AreEqual("6", node.Attribute(XName.Get("skipped")).Value);
@@ -58,8 +58,8 @@ namespace NUnit.Xml.TestLogger.AcceptanceTests
             var node = this.resultsXml.XPathSelectElement("/test-run/test-suite[@type='Assembly']");
 
             Assert.IsNotNull(node);
-            Assert.AreEqual("53", node.Attribute(XName.Get("total")).Value);
-            Assert.AreEqual("25", node.Attribute(XName.Get("passed")).Value);
+            Assert.AreEqual("52", node.Attribute(XName.Get("total")).Value);
+            Assert.AreEqual("24", node.Attribute(XName.Get("passed")).Value);
             Assert.AreEqual("14", node.Attribute(XName.Get("failed")).Value);
             Assert.AreEqual("8", node.Attribute(XName.Get("inconclusive")).Value);
             Assert.AreEqual("6", node.Attribute(XName.Get("skipped")).Value);

--- a/test/NUnit.Xml.TestLogger.AcceptanceTests/NUnitTestLoggerAcceptanceTests.cs
+++ b/test/NUnit.Xml.TestLogger.AcceptanceTests/NUnitTestLoggerAcceptanceTests.cs
@@ -40,8 +40,8 @@ namespace NUnit.Xml.TestLogger.AcceptanceTests
             var node = this.resultsXml.XPathSelectElement("/test-run");
 
             Assert.IsNotNull(node);
-            Assert.AreEqual("52", node.Attribute(XName.Get("testcasecount")).Value);
-            Assert.AreEqual("24", node.Attribute(XName.Get("passed")).Value);
+            Assert.AreEqual("53", node.Attribute(XName.Get("testcasecount")).Value);
+            Assert.AreEqual("25", node.Attribute(XName.Get("passed")).Value);
             Assert.AreEqual("14", node.Attribute(XName.Get("failed")).Value);
             Assert.AreEqual("8", node.Attribute(XName.Get("inconclusive")).Value);
             Assert.AreEqual("6", node.Attribute(XName.Get("skipped")).Value);
@@ -58,8 +58,8 @@ namespace NUnit.Xml.TestLogger.AcceptanceTests
             var node = this.resultsXml.XPathSelectElement("/test-run/test-suite[@type='Assembly']");
 
             Assert.IsNotNull(node);
-            Assert.AreEqual("52", node.Attribute(XName.Get("total")).Value);
-            Assert.AreEqual("24", node.Attribute(XName.Get("passed")).Value);
+            Assert.AreEqual("53", node.Attribute(XName.Get("total")).Value);
+            Assert.AreEqual("25", node.Attribute(XName.Get("passed")).Value);
             Assert.AreEqual("14", node.Attribute(XName.Get("failed")).Value);
             Assert.AreEqual("8", node.Attribute(XName.Get("inconclusive")).Value);
             Assert.AreEqual("6", node.Attribute(XName.Get("skipped")).Value);

--- a/test/NUnit.Xml.TestLogger.AcceptanceTests/NUnitTestLoggerPathTests.cs
+++ b/test/NUnit.Xml.TestLogger.AcceptanceTests/NUnitTestLoggerPathTests.cs
@@ -5,9 +5,6 @@ namespace NUnit.Xml.TestLogger.AcceptanceTests
 {
     using System;
     using System.IO;
-    using System.Linq;
-    using System.Xml.Linq;
-    using System.Xml.XPath;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]
@@ -39,7 +36,7 @@ namespace NUnit.Xml.TestLogger.AcceptanceTests
             string[] expectedResultsFiles = new string[]
             {
                 Path.Combine(DotnetTestFixture.RootDirectory, "NUnit.Xml.TestLogger.NetMulti.Tests.NETFramework46.test-results.xml"),
-                Path.Combine(DotnetTestFixture.RootDirectory, "NUnit.Xml.TestLogger.NetMulti.Tests.NETCoreApp20.test-results.xml")
+                Path.Combine(DotnetTestFixture.RootDirectory, "NUnit.Xml.TestLogger.NetMulti.Tests.NETCoreApp30.test-results.xml")
             };
             foreach (string resultsFile in expectedResultsFiles)
             {

--- a/test/NUnit.Xml.TestLogger.AcceptanceTests/NUnitTestLoggerResultDirectoryAcceptanceTests.cs
+++ b/test/NUnit.Xml.TestLogger.AcceptanceTests/NUnitTestLoggerResultDirectoryAcceptanceTests.cs
@@ -5,9 +5,6 @@ namespace NUnit.Xml.TestLogger.AcceptanceTests
 {
     using System;
     using System.IO;
-    using System.Linq;
-    using System.Xml.Linq;
-    using System.Xml.XPath;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]
@@ -26,13 +23,15 @@ namespace NUnit.Xml.TestLogger.AcceptanceTests
                         "assets",
                         "NUnit.Xml.TestLogger.NetCore.Tests"));
             DotnetTestFixture.TestAssemblyName = "NUnit.Xml.TestLogger.NetCore.Tests.dll";
-            DotnetTestFixture.Execute("test-results.xml", "./artifacts");
+            var testResultsPath = Path.Combine(DotnetTestFixture.RootDirectory, "artifacts");
+            DotnetTestFixture.Execute("test-results.xml", testResultsPath);
         }
 
         [TestMethod]
         public void TestRunWithResultDirectoryAndFileNameShouldCreateResultsFile()
         {
-            Assert.IsTrue(File.Exists(Path.Combine(DotnetTestFixture.RootDirectory, "artifacts", "test-results.xml")));
+            var expectedResultsPath = Path.Combine(DotnetTestFixture.RootDirectory, "artifacts", "test-results.xml");
+            Assert.IsTrue(File.Exists(expectedResultsPath), $"Results file at '{expectedResultsPath}' not found.");
         }
     }
 }

--- a/test/NUnit.Xml.TestLogger.UnitTests/NUnit.Xml.TestLogger.UnitTests.csproj
+++ b/test/NUnit.Xml.TestLogger.UnitTests/NUnit.Xml.TestLogger.UnitTests.csproj
@@ -6,7 +6,7 @@
   <Import Project="$(SourceRoot)scripts/settings.targets" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <WarningsAsErrors>true</WarningsAsErrors>
     <EnableCodeAnalysis>true</EnableCodeAnalysis>
     <IsPackable>false</IsPackable>

--- a/test/assets/NUnit.Xml.TestLogger.NetCore.Tests/NUnit.Xml.TestLogger.NetCore.Tests.csproj
+++ b/test/assets/NUnit.Xml.TestLogger.NetCore.Tests/NUnit.Xml.TestLogger.NetCore.Tests.csproj
@@ -6,7 +6,7 @@
   <Import Project="$(SourceRoot)scripts/settings.targets" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
 
     <!-- Disable stylecop for test assets -->
     <StylecopEnabled>false</StylecopEnabled>

--- a/test/assets/NUnit.Xml.TestLogger.NetMulti.Tests/NUnit.Xml.TestLogger.NetMulti.Tests.csproj
+++ b/test/assets/NUnit.Xml.TestLogger.NetMulti.Tests/NUnit.Xml.TestLogger.NetMulti.Tests.csproj
@@ -6,7 +6,7 @@
   <Import Project="$(SourceRoot)scripts/settings.targets" />
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net46;netcoreapp3.0</TargetFrameworks>
     <FrameworkPathOverride Condition="'$(OS)' != 'Windows_NT'">/usr/lib/mono/4.5/</FrameworkPathOverride>
 
     <!-- Disable stylecop for test assets -->


### PR DESCRIPTION
Fix a test with incorrect directory path. .NET Core vstest runner appears to
not set the current working directory to test dll.