### PR TITLE
Tuple missing types

### DIFF
--- a/src/NUnit.Xml.TestLogger/TestCaseNameParser.cs
+++ b/src/NUnit.Xml.TestLogger/TestCaseNameParser.cs
@@ -56,6 +56,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger
 
             var step = NameParseStep.FindMethod;
             var state = NameParseState.Default;
+            var parenthesisCount = 0;
 
             var output = new List<char>();
 
@@ -71,7 +72,12 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger
                     }
                     else if (state == NameParseState.Default)
                     {
-                        if (thisChar == '(' || thisChar == '"' || thisChar == '\\')
+                        if (thisChar == '(')
+                        {
+                            parenthesisCount--;
+                        }
+
+                        if (thisChar == '"')
                         {
                             throw new Exception("Found invalid characters");
                         }
@@ -125,7 +131,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger
                     {
                         if (thisChar == ')')
                         {
-                            throw new Exception("Found invalid characters");
+                            parenthesisCount++;
                         }
 
                         if (thisChar == '(')
@@ -155,6 +161,11 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger
 
                         output.Insert(0, thisChar);
                     }
+                }
+
+                if (parenthesisCount != 0)
+                {
+                    throw new Exception($"Unbalanced count of parentheses found ({parenthesisCount})");
                 }
 
                 // We are done. If we are finding type, set that variable.

--- a/src/NUnit.Xml.TestLogger/TestCaseNameParser.cs
+++ b/src/NUnit.Xml.TestLogger/TestCaseNameParser.cs
@@ -83,7 +83,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger
                         }
                         else if (thisChar == ')')
                         {
-                            if (output.Count > 0)
+                            if ((output.Count > 0) && (parenthesisCount == 0))
                             {
                                 throw new Exception("The closing parenthesis we detected wouldn't be the last character in the output string. This isn't acceptable because we aren't in a string");
                             }

--- a/src/NUnit.Xml.TestLogger/TestCaseNameParser.cs
+++ b/src/NUnit.Xml.TestLogger/TestCaseNameParser.cs
@@ -77,7 +77,12 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger
                             parenthesisCount--;
                         }
 
-                        if (thisChar == '"')
+                        // Backslashes allowed only inside parenthesis block
+                        if ((thisChar == '\\') && (parenthesisCount == 0))
+                        {
+                            throw new Exception("Found invalid characters");
+                        }
+                        else if (thisChar == '"')
                         {
                             throw new Exception("Found invalid characters");
                         }

--- a/test/NUnit.Xml.TestLogger.UnitTests/TestCaseNameParserTests.cs
+++ b/test/NUnit.Xml.TestLogger.UnitTests/TestCaseNameParserTests.cs
@@ -34,6 +34,8 @@ namespace NUnit.Xml.TestLogger.UnitTests
         // Test with tuple arguments
         [DataRow("z.a.b((0,1))", "z", "a", "b((0,1))")]
         [DataRow("z.a.b((\"arg\",1))", "z", "a", "b((\"arg\",1))")]
+        [DataRow("z.a.b((0,1),(2,3))", "z", "a", "b((0,1),(2,3))")]
+        [DataRow("z.a.b((0,(0,1)),(0,1))", "z", "a", "b((0,(0,1)),(0,1))")]
         public void Parse_ParsesAllParsableInputs_WithoutConsoleOutput(string testCaseName, string expectedNamespace, string expectedType, string expectedMethod)
         {
             var expected = new Tuple<string, string>(expectedType, expectedMethod);

--- a/test/NUnit.Xml.TestLogger.UnitTests/TestCaseNameParserTests.cs
+++ b/test/NUnit.Xml.TestLogger.UnitTests/TestCaseNameParserTests.cs
@@ -100,6 +100,10 @@ namespace NUnit.Xml.TestLogger.UnitTests
         [DataRow("z.y.x.")]
         [DataRow("z.y.x.)")]
         [DataRow("z.y.x.\"\")")]
+        [DataRow("z.a.b((0,1)")]
+        [DataRow("z.a.b((0,1)))")]
+        [DataRow("z.a.b((0,(0,1))")]
+        [DataRow("z.a.b((0,(0,1))))")]
         public void Parse_FailsGracefullyOnNonParsableInputs_WithConsoleOutput(string testCaseName)
         {
             var expectedConsole = string.Format(

--- a/test/NUnit.Xml.TestLogger.UnitTests/TestCaseNameParserTests.cs
+++ b/test/NUnit.Xml.TestLogger.UnitTests/TestCaseNameParserTests.cs
@@ -30,6 +30,10 @@ namespace NUnit.Xml.TestLogger.UnitTests
 
         // See nunit.testlogger #66.
         [DataRow("z.y.x.ape.bar(a\\b)", "z.y.x", "ape", "bar(a\\b)")]
+
+        // Test with tuple arguments
+        [DataRow("z.a.b((0,1))", "z", "a", "b((0,1))")]
+        [DataRow("z.a.b((\"arg\",1))", "z", "a", "b((\"arg\",1))")]
         public void Parse_ParsesAllParsableInputs_WithoutConsoleOutput(string testCaseName, string expectedNamespace, string expectedType, string expectedMethod)
         {
             var expected = new Tuple<string, string>(expectedType, expectedMethod);


### PR DESCRIPTION
Closes #64 
The proposed solution to track extra parentheses:
Instead of treat additional parentheses as an error in place, ensure that they are balanced (e.g., two closed and two open)
New tests, covers tuple case, included