### PR TITLE
Fix: Resolves #66. Allows backslash inside parenthesis, even without quotes

### DIFF
--- a/scripts/dependencies.props
+++ b/scripts/dependencies.props
@@ -10,6 +10,6 @@
     <NUnitVersion>3.10.1</NUnitVersion>
     <NUnitTestAdapterVersion>3.10.0</NUnitTestAdapterVersion>
 
-    <StylecopVersion>1.1.0-beta009</StylecopVersion>
+    <StylecopVersion>1.1.118</StylecopVersion>
   </PropertyGroup>
 </Project>

--- a/src/NUnit.Xml.TestLogger/TestCaseNameParser.cs
+++ b/src/NUnit.Xml.TestLogger/TestCaseNameParser.cs
@@ -123,7 +123,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger
                     }
                     else if (state == NameParseState.Parenthesis)
                     {
-                        if (thisChar == ')' || thisChar == '\\')
+                        if (thisChar == ')')
                         {
                             throw new Exception("Found invalid characters");
                         }

--- a/test/NUnit.Xml.TestLogger.UnitTests/TestCaseNameParserTests.cs
+++ b/test/NUnit.Xml.TestLogger.UnitTests/TestCaseNameParserTests.cs
@@ -27,6 +27,9 @@ namespace NUnit.Xml.TestLogger.UnitTests
         // Tests with longer type and method names
         [DataRow("z.y.x.ape.bar(\"ar.g\",\"\\\"\")", "z.y.x", "ape", "bar(\"ar.g\",\"\\\"\")")]
         [DataRow("z.y.x.ape.bar(\"ar.g\",\")(\")", "z.y.x", "ape", "bar(\"ar.g\",\")(\")")]
+
+        // See nunit.testlogger #66.
+        [DataRow("z.y.x.ape.bar(a\\b)", "z.y.x", "ape", "bar(a\\b)")]
         public void Parse_ParsesAllParsableInputs_WithoutConsoleOutput(string testCaseName, string expectedNamespace, string expectedType, string expectedMethod)
         {
             var expected = new Tuple<string, string>(expectedType, expectedMethod);


### PR DESCRIPTION
This resolves #66 . It doesn't seem like it would be a common issue, but this should be safe to change. 