### PR TITLE
fix: upgrade testlogger version.

### DIFF
--- a/scripts/dependencies.props
+++ b/scripts/dependencies.props
@@ -4,12 +4,12 @@
     <MSTestVersion>1.3.2</MSTestVersion>
     <NETTestSdkVersion>15.7.2</NETTestSdkVersion>
     <MoqVersion>4.9.0</MoqVersion>
-    <TestLoggerVersion>3.0.31</TestLoggerVersion>
+    <TestLoggerVersion>3.0.37</TestLoggerVersion>
 
     <!-- Test Assets use the minimum supported versions -->
     <NETTestSdkMinimumVersion>15.0.0</NETTestSdkMinimumVersion>
-    <NUnitVersion>3.10.1</NUnitVersion>
-    <NUnitTestAdapterVersion>3.10.0</NUnitTestAdapterVersion>
+    <NUnitVersion>3.13.2</NUnitVersion>
+    <NUnitTestAdapterVersion>4.0.0-beta.2</NUnitTestAdapterVersion>
 
     <StylecopVersion>1.1.118</StylecopVersion>
   </PropertyGroup>

--- a/src/NUnit.Xml.TestLogger/NUnitXmlSerializer.cs
+++ b/src/NUnit.Xml.TestLogger/NUnitXmlSerializer.cs
@@ -48,7 +48,8 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger
         public string Serialize(
             LoggerConfiguration loggerConfiguration,
             TestRunConfiguration runConfiguration,
-            List<TestResultInfo> results)
+            List<TestResultInfo> results,
+            List<TestMessageInfo> messages)
         {
             var doc = new XDocument(this.CreateTestRunElement(results, runConfiguration));
             return doc.ToString();


### PR DESCRIPTION
Assembly resolution conflict is caused when different
testloggers are used with different dependency on the
common testlogger. E.g. junit.testlogger and nunit.testlogger
depend on different common testloggers. This may result
in an exception while loading the outdated logger due to
breaking APIs in common testlogger.

Fixes #80