### PR TITLE
Illegal xml char

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "dotnet.defaultSolution": "nunit.testlogger.sln"
+}

--- a/scripts/dependencies.props
+++ b/scripts/dependencies.props
@@ -4,7 +4,7 @@
     <MSTestVersion>1.3.2</MSTestVersion>
     <NETTestSdkVersion>15.7.2</NETTestSdkVersion>
     <MoqVersion>4.9.0</MoqVersion>
-    <TestLoggerVersion>3.0.119</TestLoggerVersion>
+    <TestLoggerVersion>3.0.122</TestLoggerVersion>
 
     <!-- Test Assets use the minimum supported versions -->
     <NETTestSdkMinimumVersion>15.0.0</NETTestSdkMinimumVersion>

--- a/scripts/dependencies.props
+++ b/scripts/dependencies.props
@@ -4,7 +4,7 @@
     <MSTestVersion>1.3.2</MSTestVersion>
     <NETTestSdkVersion>15.7.2</NETTestSdkVersion>
     <MoqVersion>4.9.0</MoqVersion>
-    <TestLoggerVersion>3.0.86</TestLoggerVersion>
+    <TestLoggerVersion>3.0.119</TestLoggerVersion>
 
     <!-- Test Assets use the minimum supported versions -->
     <NETTestSdkMinimumVersion>15.0.0</NETTestSdkMinimumVersion>

--- a/src/NUnit.Xml.TestLogger.TestAdapter/NUnit.Xml.TestLogger.TestAdapter.csproj
+++ b/src/NUnit.Xml.TestLogger.TestAdapter/NUnit.Xml.TestLogger.TestAdapter.csproj
@@ -24,11 +24,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="15.5.0" />
+    <PackageReference Include="Spekt.TestLogger" Version="$(TestLoggerVersion)" />
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
-  </ItemGroup>
-
-    <ItemGroup>
-    <ProjectReference Include="..\..\..\testlogger\src\TestLogger\TestLogger.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/NUnit.Xml.TestLogger.TestAdapter/NUnit.Xml.TestLogger.TestAdapter.csproj
+++ b/src/NUnit.Xml.TestLogger.TestAdapter/NUnit.Xml.TestLogger.TestAdapter.csproj
@@ -24,8 +24,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="15.5.0" />
-    <PackageReference Include="Spekt.TestLogger" Version="$(TestLoggerVersion)" />
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
+  </ItemGroup>
+
+    <ItemGroup>
+    <ProjectReference Include="..\..\..\testlogger\src\TestLogger\TestLogger.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/NUnit.Xml.TestLogger/NUnit.Xml.TestLogger.csproj
+++ b/src/NUnit.Xml.TestLogger/NUnit.Xml.TestLogger.csproj
@@ -15,10 +15,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="15.5.0" />
+    <PackageReference Include="Spekt.TestLogger" Version="$(TestLoggerVersion)" />
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
   </ItemGroup>
 
-    <ItemGroup>
-    <ProjectReference Include="..\..\..\testlogger\src\TestLogger\TestLogger.csproj" />
-  </ItemGroup>
 </Project>

--- a/src/NUnit.Xml.TestLogger/NUnit.Xml.TestLogger.csproj
+++ b/src/NUnit.Xml.TestLogger/NUnit.Xml.TestLogger.csproj
@@ -15,10 +15,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="15.5.0" />
-    <PackageReference Include="Spekt.TestLogger" Version="$(TestLoggerVersion)" />
-    <!--<PackageReference Include="Spekt.TestLogger" Version="$(TestLoggerVersion)">-->
-      <!--<PrivateAssets>all</PrivateAssets>-->
-    <!--</PackageReference>-->
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
+  </ItemGroup>
+
+    <ItemGroup>
+    <ProjectReference Include="..\..\..\testlogger\src\TestLogger\TestLogger.csproj" />
   </ItemGroup>
 </Project>

--- a/src/NUnit.Xml.TestLogger/NUnitXmlSerializer.cs
+++ b/src/NUnit.Xml.TestLogger/NUnitXmlSerializer.cs
@@ -244,7 +244,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger
         {
             var element = new XElement(
                 "test-case",
-                new XAttribute("name", result.Method),
+                new XAttribute("name", result.TestCaseDisplayName),
                 new XAttribute("fullname", result.FullTypeName + "." + result.Method),
                 new XAttribute("methodname", result.Method),
                 new XAttribute("classname", result.Type),

--- a/src/NUnit.Xml.TestLogger/NUnitXmlSerializer.cs
+++ b/src/NUnit.Xml.TestLogger/NUnitXmlSerializer.cs
@@ -253,8 +253,8 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger
                 new XAttribute("end-time", result.EndTime.ToString(DateFormat, CultureInfo.InvariantCulture)),
                 new XAttribute("duration", result.Duration.TotalSeconds),
                 new XAttribute("asserts", 0),
-                CreateSeedAttribute(result.TestCase),
-                CreatePropertiesElement(result.TestCase));
+                CreateSeedAttribute(result),
+                CreatePropertiesElement(result));
 
             StringBuilder stdOut = new StringBuilder();
             foreach (var m in result.Messages)
@@ -281,15 +281,15 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger
             return element;
         }
 
-        private static XAttribute CreateSeedAttribute(TestCase result)
+        private static XAttribute CreateSeedAttribute(TestResultInfo result)
         {
-            var seed = result.Properties.SingleOrDefault(p => p.Id == "NUnit.Seed");
-            return seed != null
-                ? new XAttribute("seed", result.GetPropertyValue(seed))
+            var seed = result.Properties.SingleOrDefault(p => p.Key == "NUnit.Seed");
+            return seed.Key == "NUnit.Seed"
+                ? new XAttribute("seed", seed.Value)
                 : null;
         }
 
-        private static XElement CreatePropertiesElement(TestCase result)
+        private static XElement CreatePropertiesElement(TestResultInfo result)
         {
             var propertyElements = new HashSet<XElement>(result.Traits.Select(CreatePropertyElement));
 
@@ -297,16 +297,15 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger
 
             // Required since TestCase.Properties is a superset of TestCase.Traits
             // Unfortunately not all NUnit properties are available as traits
-            var traitProperties = result.Properties.Where(t => t.Attributes.HasFlag(TestPropertyAttributes.Trait));
+            var traitProperties = result.Properties;
 
 #pragma warning restore CS0618 // Type or member is obsolete
 
             foreach (var p in traitProperties)
             {
-                var propValue = result.GetPropertyValue(p);
-
-                if (p.Id == "NUnit.TestCategory")
+                if (p.Key == "NUnit.TestCategory")
                 {
+                    var propValue = p.Value;
                     var elements = CreatePropertyElement("Category", (string[])propValue);
 
                     foreach (var element in elements)

--- a/src/NUnit.Xml.TestLogger/NUnitXmlSerializer.cs
+++ b/src/NUnit.Xml.TestLogger/NUnitXmlSerializer.cs
@@ -244,7 +244,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger
         {
             var element = new XElement(
                 "test-case",
-                new XAttribute("name", result.TestCase.DisplayName),
+                new XAttribute("name", result.TestCaseDisplayName),
                 new XAttribute("fullname", result.FullTypeName + "." + result.Method),
                 new XAttribute("methodname", result.Method),
                 new XAttribute("classname", result.Type),

--- a/src/NUnit.Xml.TestLogger/NUnitXmlSerializer.cs
+++ b/src/NUnit.Xml.TestLogger/NUnitXmlSerializer.cs
@@ -244,7 +244,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger
         {
             var element = new XElement(
                 "test-case",
-                new XAttribute("name", result.TestCaseDisplayName),
+                new XAttribute("name", result.Method),
                 new XAttribute("fullname", result.FullTypeName + "." + result.Method),
                 new XAttribute("methodname", result.Method),
                 new XAttribute("classname", result.Type),

--- a/src/NUnit.Xml.TestLogger/NUnitXmlSerializer.cs
+++ b/src/NUnit.Xml.TestLogger/NUnitXmlSerializer.cs
@@ -244,7 +244,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger
         {
             var element = new XElement(
                 "test-case",
-                new XAttribute("name", result.TestCaseDisplayName),
+                new XAttribute("name", result.DisplayName),
                 new XAttribute("fullname", result.FullTypeName + "." + result.Method),
                 new XAttribute("methodname", result.Method),
                 new XAttribute("classname", result.Type),

--- a/src/NUnit.Xml.TestLogger/NUnitXmlSerializer.cs
+++ b/src/NUnit.Xml.TestLogger/NUnitXmlSerializer.cs
@@ -274,8 +274,8 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger
             {
                 element.Add(new XElement(
                     "failure",
-                    new XElement("message", result.ErrorMessage.ReplaceInvalidXmlChar()),
-                    new XElement("stack-trace", result.ErrorStackTrace.ReplaceInvalidXmlChar())));
+                    new XElement("message", result.ErrorMessage),
+                    new XElement("stack-trace", result.ErrorStackTrace)));
             }
 
             return element;

--- a/src/NUnit.Xml.TestLogger/NUnitXmlSerializer.cs
+++ b/src/NUnit.Xml.TestLogger/NUnitXmlSerializer.cs
@@ -20,6 +20,8 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger
         private const string ResultStatusPassed = "Passed";
         private const string ResultStatusFailed = "Failed";
 
+        public IInputSanitizer InputSanitizer { get;  } = new InputSanitizerXml();
+
         public static IEnumerable<TestSuite> GroupTestSuites(IEnumerable<TestSuite> suites)
         {
             var groups = suites;


### PR DESCRIPTION
Continuation of https://github.com/spekt/nunit.testlogger/pull/98

* Use xml sanitization from TestLogger core.
* Use DisplayName for method name and Properties attributes for NUnit.Seed/TestCategory reporting.